### PR TITLE
Partial widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,6 @@ var invitesAccepted = {
     }]
 }
 ```
+
+### Tests
+To run the tests, just open tests/test.html in the browser.

--- a/tests/test_SuperwidgetEvents.js
+++ b/tests/test_SuperwidgetEvents.js
@@ -1,0 +1,27 @@
+setTimeout(runTests, 3000);  // Give scripts time to load before starting
+
+function runTests(){
+
+    QUnit.test("EVENTS: set.yesgraph.recipients", function(assert) {
+        var done = assert.async(),
+            exampleEmails = ["jane@example.com", "joe@example.com"],
+            condition;
+
+        // Set event handler
+        $(document).on("set.yesgraph.recipients", function(evt, recipients){
+            // Pass the test when we catch the event
+            assert.equal(evt.type, "set", "Found matching event type: set");
+            assert.equal(evt.namespace, "recipients.yesgraph", "Found matching event namespace: recipients.yesgraph");
+            
+            for (var i=0; i<exampleEmails.length; i++) {
+                var foundEmail = recipients[i].email;
+                assert.equal(foundEmail, exampleEmails[i], "Found matching recipient: " + foundEmail);
+            }
+            done();
+        });
+
+        // Simulate the behavior that should trigger the event
+        $(".yes-manual-input-field").val(exampleEmails.join(", "));
+        $(".yes-manual-input-submit").trigger("click");
+    });
+}

--- a/tests/test_SuperwidgetUI.js
+++ b/tests/test_SuperwidgetUI.js
@@ -1,0 +1,27 @@
+setTimeout(runTests, 3000);  // Give scripts time to load before starting
+
+function runTests(){
+
+    // Test that each component of the widget container appears
+    QUnit.test("UI: Widget Container", function(assert) {
+        var condition = $(".yes-widget-container").length > 0;
+        assert.ok(condition, "Found .yes-widget-container");
+
+        var condition = $(".yes-widget-container").length > 0;
+        assert.ok(condition, "Found .yes-widget-container");
+        var selectors = {
+            ".yes-widget-container": 1,
+            ".yes-contact-import-btn": 2,
+            ".yes-manual-input-field": 1,
+            ".yes-manual-input-submit": 1,
+            "#yes-invite-link": 1,
+            "#yes-invite-link-copy-btn": 1,
+            ".yes-share-btn": 4
+        }
+
+        for (selector in selectors) {
+            var count = selectors[selector];
+            assert.equal($(selector).length, count, "Found " + count + " " + selector);
+        }
+    });
+}

--- a/tests/test_YesGraphAPI.js
+++ b/tests/test_YesGraphAPI.js
@@ -1,0 +1,17 @@
+setTimeout(runTests, 3000);  // Give scripts time to load before starting
+
+function runTests(){
+
+    QUnit.test("YesGraphAPI", function(assert) {
+        assert.ok(window.YesGraphAPI, "Found YesGraphAPI");
+        assert.ok(YesGraphAPI.hasClientToken(), "YesGraphAPI has Client Token");
+        assert.ok(YesGraphAPI.getInviteLink(), "Found Invite Link");
+
+        var done = assert.async();
+        YesGraphAPI.test().always(function(response){
+            condition = !response.error;
+            assert.ok(condition, response.message);
+            done();
+        });
+    });
+}

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>YesGraph Superwidget QUnit Tests</title>
+  <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.23.1.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+  <div id="yesgraph" class="yesgraph-invites" data-testmode=true data-app="19185f1f-a583-4c6b-bc5f-8aff04dc1020" data-foo="bar"></div>
+  
+  <script src="https://code.jquery.com/qunit/qunit-1.23.1.js"></script>
+  <!-- Tests Local Versions of Superwidget -->
+  <script src="../yesgraph.js" data-cover=true></script>
+  <script src="../yesgraph-invites.js" data-cover=true></script>
+  <script src="test_YesGraphAPI.js"></script>
+  <script src="test_SuperwidgetUI.js"></script>
+  <script src="test_SuperwidgetEvents.js"></script>
+</body>
+</html>

--- a/yesgraph-invites.css
+++ b/yesgraph-invites.css
@@ -96,6 +96,14 @@
     margin-right: 0;
 }
 
+.yes-widget-container .yes-contact-import-btn-google .yes-contact-import-btn-icon {
+    background-image: url("https://cdn.yesgraph.com/google.png");
+}
+
+.yes-widget-container .yes-contact-import-btn-outlook .yes-contact-import-btn-icon {
+    background-image: url("https://cdn.yesgraph.com/outlook.png");
+}
+
 .yes-widget-container .yes-share-btn-section {
     margin-top: 10px;
     text-align: center;
@@ -109,7 +117,9 @@
     padding: 5px 7px 5px 5px;
 }
 
-.yes-widget-container .yes-share-btn, .yes-widget-container .yes-share-btn-text, .yes-widget-container .yes-share-btn-icon {
+.yes-widget-container .yes-share-btn,
+.yes-widget-container .yes-share-btn-text,
+.yes-widget-container .yes-share-btn-icon {
   cursor: pointer;
 }
 

--- a/yesgraph-invites.js
+++ b/yesgraph-invites.js
@@ -38,6 +38,7 @@
                     var APP_NAME,
                         target,
                         TESTMODE,
+                        OPTIONS,
                         YESGRAPH_BASE_URL = (window.location.hostname === 'localhost' && window.document.title === 'YesGraph') ? 'http://localhost:5001' : 'https://www.yesgraph.com',
                         // Sections of the widget UI
                         container = $("<div>", {
@@ -141,8 +142,8 @@
 
                     var contactsModal = (function() {
                         var modal = $("<div>", {
-                            "class": "yes-modal"
-                        }),
+                                "class": "yes-modal"
+                            }),
                             overlay = $("<div>", {
                                 "class": "yes-modal-overlay"
                             }),
@@ -203,8 +204,8 @@
                                 "text": "Select All"
                             }));
 
-                        function init(options) {
-                            var widgetCopy = options.widgetCopy || {};
+                        function init() {
+                            var widgetCopy = OPTIONS.widgetCopy || {};
 
                             titleText = widgetCopy.contactsModalHeader || "Add Friends";
                             modalTitle.text(titleText)
@@ -218,10 +219,7 @@
                             $(window).on("resize", centerModal);
                             modalCloseBtn.on("click", closeModal);
                             overlay.on("click", closeModal);
-
-                            modalSendBtn.on("click", function() {
-                                validateSettings(options.settings || {}) ? send() : closeModal();
-                            });
+                            modalSendBtn.on("click", send);
 
                             selectAll.on("click", function(evt) {
                                 modalBody.find("[type='checkbox']").prop("checked", $(evt.target).prop("checked"));
@@ -574,7 +572,7 @@
 
                     var inviteWidget = (function() {
 
-                        function init(options) {
+                        function init() {
                             var settings = YesGraphAPI.getSettings() || {},
                                 targetSelector = settings.target || ".yesgraph-invites";
                             $(targetSelector).append(container);
@@ -587,11 +585,11 @@
                             sections.push(flashSection);
                             container.append(sections);
 
-                            if (options.poweredByYesgraph) {
+                            if (OPTIONS.poweredByYesgraph) {
                                 container.append(poweredByYesgraph);
                             };
 
-                            var widgetCopy = options.widgetCopy || {};
+                            var widgetCopy = OPTIONS.widgetCopy || {};
                             // Build container header
                             if (widgetCopy.widgetHeadline) {
                                 var headline = $("<p>", {
@@ -615,7 +613,7 @@
                             });
 
                             // Build share button section
-                            buildShareButtons(shareBtnSection, options);
+                            buildShareButtons(shareBtnSection);
 
                             // Build container body
                             var manualInputForm = $('<form>', {
@@ -630,8 +628,8 @@
                                     "text": widgetCopy.manualInputSendBtn || "Add Emails",
                                     "class": "yes-default-btn yes-manual-input-submit",
                                 }),
-                                includeOutlook = options.settings.oauthServices.indexOf("outlook") !== -1,
-                                includeGoogle = options.settings.oauthServices.indexOf("google") !== -1,
+                                includeOutlook = OPTIONS.settings.oauthServices.indexOf("outlook") !== -1,
+                                includeGoogle = OPTIONS.settings.oauthServices.indexOf("google") !== -1,
                                 contactImportSection = $("<div>", {
                                     "class": "yes-contact-import-section"
                                 }),
@@ -642,23 +640,22 @@
                             if (settings.contactImporting) { containerBody.append(contactImportSection); };
                             if (settings.emailSending) { containerBody.append(manualInputForm); };
 
-                            contactsModal.init(options);
+                            contactsModal.init();
 
                             manualInputSubmit.on("click", function(evt) {
                                 evt.preventDefault();
-                                if (validateSettings(options.settings || {})) {
-                                    send();
-                                    manualInputField.val("");
-                                };
+                                var recipients = getSelectedRecipients(manualInputField);
+                                sendEmailInvites(recipients);
+                                manualInputField.val("");
                             });
 
                             // Set up the contact importing buttons
-                            if (options.settings.oauthServices.length <= 1) {
-                                btnText = (options.widgetCopy.contactImportBtnCta || "Find friends") + " with ";
+                            if (OPTIONS.settings.oauthServices.length <= 1) {
+                                btnText = (OPTIONS.widgetCopy.contactImportBtnCta || "Find friends") + " with ";
                             }
                             if (includeGoogle) {
                                 var gmailBtn = generateContactImportBtn({
-                                    "id": "gmail",
+                                    "id": "google",
                                     "name": "Gmail"
                                 });
                                 contactImportSection.append(gmailBtn);
@@ -667,10 +664,10 @@
                                 gmailBtn.on("click", function(evt) {
                                     // Attempt to auth gmail & pull contacts
                                     evt.preventDefault();
-                                    gmail.authPopup(options).done(function() {
+                                    gmail.authPopup().done(function() {
                                         contactsModal.openModal();
                                         contactsModal.loading();
-                                        gmail.getContacts(options)
+                                        gmail.getContacts()
                                             .done(
                                                 function(contacts) {
                                                     rankContacts(contacts).done(function(contacts) {
@@ -700,7 +697,7 @@
                                 // Define oauth behavior for Outlook
                                 outlookBtn.on("click", function(evt){
                                     // Attempt to auth & pull contacts
-                                    outlook.authPopup(options).done(function(contacts){
+                                    outlook.authPopup().done(function(contacts){
                                         if (!contactsModal.isOpen) contactsModal.openModal();
                                         contactsModal.loadContacts(contacts);
                                     }).fail(function(data){
@@ -710,18 +707,8 @@
                                 });
                             }
 
-                            function send(evt) {
-                                try {
-                                    evt.preventDefault();
-                                } catch (e) {};
-
-                                var recipients = getSelectedRecipients(manualInputField);
-                                sendEmailInvites(recipients);
-                            }
-
                             function generateContactImportBtn(service) {
                                 var icon = $("<div>", {
-                                        "style": "background-image: url('" + protocol + "//cdn.yesgraph.com/" + service.id + ".png')",
                                         "class": "yes-contact-import-btn-icon",
                                     }),
                                     text = $("<span>", {
@@ -734,7 +721,7 @@
                                         "vertical-align": "middle",
                                     }).append(innerWrapper),
                                     btn = $("<button>", {
-                                        "class": "yes-default-btn yes-contact-import-btn"
+                                        "class": "yes-default-btn yes-contact-import-btn yes-contact-import-btn-" + service.id
                                     }).append(outerWrapper);
                                 return btn;
                             };
@@ -746,6 +733,7 @@
                                 OPTIONS_ENDPOINT = '/apps/' + APP_NAME + '/js/get-options';
 
                             YesGraphAPI.hitAPI(OPTIONS_ENDPOINT, "GET").done(function(data) {
+                                OPTIONS = data;
                                 d.resolve(data);
                             }).fail(function(error) {
                                 YesGraphAPI.error(error.error + ". Please see the YesGraph SuperWidget Dashboard.", true);
@@ -766,8 +754,8 @@
                             return d.promise();
                         }
 
-                        function buildShareButtons(target, options) {
-                            if (options.shareButtons.length === 0) return false;
+                        function buildShareButtons(target) {
+                            if (OPTIONS.shareButtons.length === 0) return false;
                             var buttonsDiv = $("<div>"),
                                 service,
                                 targ,
@@ -781,7 +769,7 @@
                                     "baseURL": "https://www.facebook.com/share.php",
                                     "params": {
                                         u: encodeURI(inviteLink),
-                                        title: options.integrations.twitter.tweetMsg
+                                        title: OPTIONS.integrations.twitter.tweetMsg
                                     },
                                     "colors": ["#3B5998", "#324b81"],
                                 }, {
@@ -789,7 +777,7 @@
                                     "name": "Twitter",
                                     "baseURL": "https://twitter.com/intent/tweet",
                                     "params": {
-                                        text: options.integrations.twitter.tweetMsg + ' ' + inviteLink
+                                        text: OPTIONS.integrations.twitter.tweetMsg + ' ' + inviteLink
                                     },
                                     "colors": ["#55ACEE", "#2E99EA"],
                                 }, {
@@ -799,8 +787,8 @@
                                     "params": {
                                         "mini": true,
                                         "url": inviteLink,
-                                        "title": options.appDisplayName,
-                                        "summary": options.integrations.twitter.tweetMsg
+                                        "title": OPTIONS.appDisplayName,
+                                        "summary": OPTIONS.integrations.twitter.tweetMsg
                                     },
                                     "colors": ["#0077B5", "#006399"],
                                 }, {
@@ -815,7 +803,7 @@
 
                             for (var i = 0; i < services.length; i++) {
                                 service = services[i];
-                                if (options.shareButtons.indexOf(service.ID) === -1) continue;
+                                if (OPTIONS.shareButtons.indexOf(service.ID) === -1) continue;
 
                                 shareBtnIcon = $("<span>", {
                                     "class": "yes-share-btn-icon"
@@ -864,7 +852,7 @@
                                         // asynchronously (e.g., by Intercom) will not
                                         // have the desired description when pinned.
                                         $("img").not("[data-pin-description]").each(function() {
-                                            this.dataset["pinDescription"] = options.integrations.twitter.tweetMsg + " " + inviteLink;
+                                            this.dataset["pinDescription"] = OPTIONS.integrations.twitter.tweetMsg + " " + inviteLink;
                                         });
                                         wrapper[0].click();
                                     });
@@ -897,10 +885,10 @@
                             readContactsScope = "https://outlook.office.com/contacts.read",
                             OUTLOOK_FAILED_MSG = "Outlook Authorization Failed";
 
-                        function authPopup(options) {
+                        function authPopup() {
                             // Open the Outlook OAuth popup & retrieve the access token from it
                             var d = $.Deferred(),
-                                oauthInfo = getOAuthInfo(options),
+                                oauthInfo = getOAuthInfo(),
                                 url = oauthInfo[0],
                                 redirect = oauthInfo[1],
                                 win = open(url, "Outlook Authorization", 'width=900, height=700'),
@@ -929,7 +917,16 @@
                                                     "service": "outlook",
                                                     "token_data": JSON.stringify(tokenData)
                                                 }).done(function(response){
-                                                    response.error ? d.reject(response) : d.resolve(response.data);
+                                                    if (response.error) {
+                                                        d.reject(response);
+                                                    } else {
+                                                        $(document).trigger(YesGraphAPI.events.IMPORTED_CONTACTS,[{
+                                                            name: undefined,
+                                                            email: undefined,
+                                                            type: "outlook"
+                                                        }, response.data ]);
+                                                        d.resolve(response.data);
+                                                    }
                                                 }).fail(function(response){
                                                     d.reject(response);
                                                 });
@@ -959,20 +956,20 @@
                                 }, 100);
 
 
-                            function getOAuthInfo(options) {
+                            function getOAuthInfo() {
                                 var REDIRECT;
-                                if (window.location.hostname === "localhost" || options.integrations.outlook.usingDefaultCredentials) {
+                                if (window.location.hostname === "localhost" || OPTIONS.integrations.outlook.usingDefaultCredentials) {
                                     REDIRECT = window.location.origin;
                                 } else {
-                                    REDIRECT = options.integrations.outlook.redirectUrl;
+                                    REDIRECT = OPTIONS.integrations.outlook.redirectUrl;
                                 }
 
                                 var authUrl = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?",
                                     params = {
                                         response_type: "token",
-                                        client_id: options.integrations.outlook.clientId,
+                                        client_id: OPTIONS.integrations.outlook.clientId,
                                         state: window.location.href,
-                                        redirect_uri: options.integrations.outlook.redirectUrl,
+                                        redirect_uri: OPTIONS.integrations.outlook.redirectUrl,
                                     },
                                     scope = concatScopes([readContactsScope]),
                                     authUrl = authUrl + $.param(params) + "&scope=" + scope;
@@ -1000,7 +997,7 @@
                     // (e.g., OAuth, contact importing, etc.)
                     var gmail = (function() {
 
-                        function getContacts(options) {
+                        function getContacts() {
                             var d = $.Deferred(),
                                 contactsFeedUrl = 'https://www.google.com/m8/feeds/contacts/default/full?max-results=1000000',
                                 readContactsScope = 'https://www.googleapis.com/auth/contacts.readonly';
@@ -1017,10 +1014,11 @@
                                 dataType: "jsonp",
                                 success: function(data) {
                                     contacts = parseContactsFeed(data.feed);
+                                    $(document).trigger(YesGraphAPI.events.IMPORTED_CONTACTS, [contacts.source, contacts.entries, data]);
                                     d.resolve(contacts);
                                 },
                                 error: function(data) {
-                                    d.reject(options);
+                                    d.reject();
                                 }
                             });
                             return d.promise();
@@ -1061,11 +1059,11 @@
                             return contacts;
                         }
 
-                        function authPopup(options) {
+                        function authPopup() {
                             // Open the Google OAuth popup & retrieve the access token from it
                             var d = $.Deferred(),
-                                url = getOAuthInfo(options)[0],
-                                redirect = getOAuthInfo(options)[1],
+                                url = getOAuthInfo()[0],
+                                redirect = getOAuthInfo()[1],
                                 win = open(url, "Google Authorization", 'width=550, height=550'),
                                 count = 0,
                                 token,
@@ -1121,19 +1119,19 @@
                                     }
                                 }, 100);
 
-                            function getOAuthInfo(options) {
+                            function getOAuthInfo() {
                                 var REDIRECT;
-                                if (window.location.hostname === "localhost" || options.integrations.google.usingDefaultCredentials) {
+                                if (window.location.hostname === "localhost" || OPTIONS.integrations.google.usingDefaultCredentials) {
                                     REDIRECT = window.location.origin;
                                 } else {
-                                    REDIRECT = options.integrations.google.redirectUrl;
+                                    REDIRECT = OPTIONS.integrations.google.redirectUrl;
                                 }
 
                                 var params = {
                                     response_type: "token",
-                                    client_id: options.integrations.google.clientId,
+                                    client_id: OPTIONS.integrations.google.clientId,
                                     state: window.location.href,
-                                    redirect_uri: options.integrations.google.redirectUrl,
+                                    redirect_uri: OPTIONS.integrations.google.redirectUrl,
                                 },
                                     scope = concatScopes(["https://www.google.com/m8/feeds/",
                                         "https://www.googleapis.com/auth/userinfo.email"
@@ -1163,14 +1161,22 @@
                     function waitForAPIConfig() {
                         var d = $.Deferred();
                         var timer = setInterval(function() {
-                            if (YesGraphAPI.getApp() && YesGraphAPI.hasClientToken() && YesGraphAPI.getInviteLink()) {
+                            if (YesGraphAPI.getApp()
+                                && YesGraphAPI.hasClientToken()
+                                && YesGraphAPI.getInviteLink()
+                                && ($(YesGraphAPI.getSettings().target).length > 0)) {
+
+                                clearInterval(timer);
+
                                 inviteLinkInput.val(YesGraphAPI.getInviteLink());
                                 YesGraphAPI.isTestMode = isTestMode;
 
-                                if ($(YesGraphAPI.getSettings().target).length > 0) {
-                                    clearInterval(timer);
-                                    d.resolve();                                    
-                                }
+                                // Add custom superwidget events
+                                YesGraphAPI.events = $.extend(YesGraphAPI.events, {
+                                    SET_RECIPIENTS: "set.yesgraph.recipients",
+                                    IMPORTED_CONTACTS: "imported.yesgraph.contacts",
+                                });
+                                d.resolve();
                             };
                         }, 100);
                         return d.promise();
@@ -1223,59 +1229,63 @@
                         if (!recipients || recipients.length < 1) {
                             var msg = "No valid recipients specified."
                             flash.error(msg);
-                            d.reject({
-                                "error": msg,
-                            });
+                            d.reject({ "error": msg }); // invalid user input
+
                         } else {
-                            YesGraphAPI.hitAPI("/send-email-invites", "POST", {
-                                recipients: recipients,
-                                test: TESTMODE || undefined,
-                                invite_link: YesGraphAPI.getInviteLink()
-                            }).done(function(resp) {
-                                if (!resp.emails) {
-                                    d.reject(resp);
-                                    flash.error(resp);
-                                    YesGraphAPI.error(resp);
-                                } else {
-                                    if (TESTMODE) {
-                                        flash.success("Testmode: emails not sent.");
-                                    } else {
-                                        var inviteData, invites = {
-                                                "entries": []
+                            // Event only fires if there are valid recipients
+                            $(document).trigger(YesGraphAPI.events.SET_RECIPIENTS, [recipients]);
+
+                            // Only send the emails if `data-email-sending` was not set to `false`
+                            if (YesGraphAPI.getSettings().emailSending) {
+
+                                if (validateSettings(OPTIONS.settings || {})) {
+                                    YesGraphAPI.hitAPI("/send-email-invites", "POST", {
+                                        recipients: recipients,
+                                        test: TESTMODE || undefined,
+                                        invite_link: YesGraphAPI.getInviteLink()
+
+                                    }).done(function(resp) {
+                                        if (!resp.emails) {
+                                            d.reject(resp);
+                                            flash.error(resp);
+                                            YesGraphAPI.error(resp);
+                                        } else {
+                                            if (TESTMODE) {
+                                                flash.success("Testmode: emails not sent.");
+                                            } else {
+                                                var msg,
+                                                    sentCount = resp.sent.length,
+                                                    inviteData,
+                                                    invites = { "entries": [] };
+
+                                                for (var i = 0; i < resp.sent.length; i++) {
+                                                    inviteData = resp.sent[i];
+                                                    invites.entries.push({
+                                                        "invitee_name": inviteData[0] || undefined,
+                                                        "email": inviteData[1],
+                                                        "sent_at": new Date().toISOString(),
+                                                    });
+                                                };
+                                                YesGraphAPI.postInvitesSent(invites);
                                             };
-                                        for (var i = 0; i < resp.emails.succeeded.length; i++) {
-                                            inviteData = resp.emails.succeeded[i];
-                                            invites.entries.push({
-                                                "invitee_name": inviteData[0] || undefined,
-                                                "email": inviteData[1],
-                                                "sent_at": new Date().toISOString(),
-                                            });
+                                            d.resolve();
                                         };
-                                        YesGraphAPI.postInvitesSent(invites);
-                                    };
-                                    // Loop through emails, flashing appropriate results
-                                    var msg,
-                                        successCount = resp.emails.succeeded.length,
-                                        failCount = resp.emails.failed.length;
 
-                                    if (successCount > 0) {
-                                        msg = "You've successfully added " + successCount;
-                                        msg += successCount === 1 ? " friend!" : " friends!";
-                                        flash.success(msg);
-                                    };
+                                    }).fail(function(data) {
+                                        flash.error(data.error);
+                                        YesGraphAPI.error(data.error, false);
+                                        d.reject(data);
+                                    });
 
-                                    if (failCount > 0) {
-                                        msg = failCount + (failCount === 1 ? " email " : " emails ") + "failed";
-                                        flash.error(msg);
-                                        flash.error(resp.emails.failed[0][-1]);
-                                    };
-                                    d.resolve();
-                                };
-                            }).fail(function(data) {
-                                flash.error(data.error);
-                                YesGraphAPI.error(data.error, false);
-                                d.reject(data);
-                            });
+                                } else {
+                                    d.reject();  // invalid settings
+                                }
+                            } else {
+                                d.resolve(); // email sending turned off
+                            }
+                            msg = "You've added " + recipients.length;
+                            msg += recipients.length === 1 ? " friend!" : " friends!";
+                            flash.success(msg);
                         };
                         return d.promise();
                     }
@@ -1314,7 +1324,6 @@
 
                     // Main functionality
                     waitForAPIConfig().then(inviteWidget.init);
-
                 }); // withScript Clipboard.js
             }); // withScript YesGraphAPI
         }); // withScript jQuery

--- a/yesgraph-invites.js
+++ b/yesgraph-invites.js
@@ -1283,9 +1283,12 @@
                             } else {
                                 d.resolve(); // email sending turned off
                             }
-                            msg = "You've added " + recipients.length;
-                            msg += recipients.length === 1 ? " friend!" : " friends!";
-                            flash.success(msg);
+
+                            d.done(function(){
+                                msg = "You've added " + recipients.length;
+                                msg += recipients.length === 1 ? " friend!" : " friends!";
+                                flash.success(msg);
+                            });
                         };
                         return d.promise();
                     }

--- a/yesgraph-invites.js
+++ b/yesgraph-invites.js
@@ -857,7 +857,7 @@
                                         wrapper[0].click();
                                     });
 
-                                    withScript("pinUtils", "//assets.pinterest.com/js/pinit.js", function() {
+                                    withScript("pinUtils", protocol + "//assets.pinterest.com/js/pinit.js", function() {
                                         buttonsDiv.append(wrapper.append(shareBtn));
                                     });
 

--- a/yesgraph.js
+++ b/yesgraph.js
@@ -237,7 +237,10 @@
 
         function hitAPI(endpoint, method, data, done, deferred) {
             var d = deferred || $.Deferred();
-            if (method.toUpperCase() !== "GET") {
+            if (!typeof method == "string") {
+                d.reject({error: "Expected method as string, not " + typeof method})
+                return d.promise();
+            } else if (method.toUpperCase() !== "GET") {
                 data = JSON.stringify(data || {});
             };
             var ajaxSettings = {
@@ -271,7 +274,7 @@
                         initDeferred.resolve(target);
                     }
                 }, 100);
-            initDeferred.done(function(){ clearInterval(timer); });
+            initDeferred.always(function(){ clearInterval(timer); });
             return initDeferred.promise();
         }
 

--- a/yesgraph.js
+++ b/yesgraph.js
@@ -41,10 +41,8 @@
         };
     }
 
-    console.log("jQuery loading");
     // Get jQuery if it hasn't been loaded separately
     withScript("jQuery", "https://code.jquery.com/jquery-2.1.1.min.js", function($) {
-        console.log("jQuery ready");
         var initDeferred = $.Deferred();
         JQUERY_VERSION = $.fn.jquery;
 
@@ -207,6 +205,9 @@
                 },
                 hasLoadedSuperwidget: false, // Updated by Superwidget
                 error: error,
+                events: {
+                    RANKED_CONTACTS: "ranked.yesgraph.contacts",
+                }
             };
 
             // Don't try to get a client token until we have found
@@ -224,7 +225,6 @@
                 }
                 getClientToken(userData).then(logScreenEvent);
             });
-            console.log("API ready");
             return api;
         }
 


### PR DESCRIPTION
#### What’s this PR do?
Allows customers to turn off specific parts of the Superwidget. In most cases this will be used by customers who only want the contact importer, and not the email sending, social share buttons, etc.

#### Any background context you want to provide?
We've been talking with customers who already have a referral program, but would want to add our contact importer to the mix. This allows them to turn off everything but the contact importer.

#### Where should the reviewer start?
Start with the changes to the `configureAPI()` method in `yesgraph.js`.

#### How should this be manually tested?
Open `tests/test.html` in the browser! I've added some tests with QUnit.
<img width="909" alt="screen shot 2016-05-09 at 9 09 17 pm" src="https://cloud.githubusercontent.com/assets/10701968/15135375/6bd8c456-162a-11e6-9186-ab2e7b97f8de.png">


#### Screenshots (if appropriate)
###### Default styling:
 <img width="249" alt="screen shot 2016-05-09 at 5 21 20 pm" src="https://cloud.githubusercontent.com/assets/10701968/15132051/7a6f5126-160a-11e6-983c-850b484792bb.png">

###### Custom styling:
<img width="212" alt="screen shot 2016-05-09 at 5 16 12 pm" src="https://cloud.githubusercontent.com/assets/10701968/15132055/84853702-160a-11e6-8bfb-e1b2f3582b2a.png">

#### What are the relevant tickets?
https://app.asana.com/0/77757700101210/131194538241617
https://app.asana.com/0/77757700101210/119313227805276

#### Does the knowledge base need an update?
Yes. I'll update docs.yesgraph.com

#### Does this require changes on the API side?
No