### PR TITLE
continue polling even if we get weird errors related to the url after…

### DIFF
--- a/dev/yesgraph-invites.js
+++ b/dev/yesgraph-invites.js
@@ -1,5 +1,5 @@
 ! function() {
-    var VERSION = "v0.0.2",
+    var VERSION = "v0.0.3",
         SDK_VERSION = "v0.0.2",
         CSS_VERSION = "v0.0.3",
         domReadyTimer = setInterval(function() {

--- a/dev/yesgraph-invites.js
+++ b/dev/yesgraph-invites.js
@@ -1,7 +1,7 @@
 ! function() {
-    var VERSION = "v0.0.3",
-        SDK_VERSION = "v0.0.2",
-        CSS_VERSION = "v0.0.3",
+    var VERSION = "dev/v0.0.3",
+        SDK_VERSION = "dev/v0.0.2",
+        CSS_VERSION = "dev/v0.0.3",
         domReadyTimer = setInterval(function() {
             if (document.readyState === "complete" || document.readyState === "interactive") {
                 loadSuperwidget();

--- a/dev/yesgraph-invites.js
+++ b/dev/yesgraph-invites.js
@@ -1,7 +1,7 @@
 ! function() {
-    var VERSION = "dev/v0.0.2",
-        SDK_VERSION = "dev/v0.0.2",
-        CSS_VERSION = "dev/v0.0.3",
+    var VERSION = "v0.0.2",
+        SDK_VERSION = "v0.0.2",
+        CSS_VERSION = "v0.0.3",
         domReadyTimer = setInterval(function() {
             if (document.readyState === "complete" || document.readyState === "interactive") {
                 loadSuperwidget();
@@ -720,7 +720,7 @@
                                         // Handle case where auth failed
                                         contactsModal.closeModal();
                                         contactsModal.stopLoading();
-                                        flash.error();
+                                        flash.error(data.error);
                                         YesGraphAPI.error(data.error);
                                     });
                                 });
@@ -1244,9 +1244,6 @@
                                                 errorMessage = getUrlParam(responseUrl, "error"),
                                                 token = getUrlParam(responseUrl, "access_token");
 
-                                            clearInterval(pollTimer);
-                                            win.close();
-
                                             if (token) {
                                                 GMAIL_ACCESS_TOKEN = token;
                                                 d.resolve({
@@ -1254,15 +1251,18 @@
                                                     type: getUrlParam(responseUrl, "token_type"),
                                                     expires_in: getUrlParam(responseUrl, "expires_in")
                                                 });
-
-                                            } else {
-                                                if (errorMessage === "Cannot read property 'URL' of undefined") {
-                                                    errorMessage = "Authorization failed."
-                                                };
+                                                clearInterval(pollTimer);
+                                                win.close();
+                                            } else if (errorMessage === "access_denied") {
                                                 d.reject({
-                                                    "error": errorMessage
+                                                    "error": "Access Denied"
                                                 });
+                                                clearInterval(pollTimer);
+                                                win.close();
                                             };
+                                            // If access was neither granted nor denied, keep waiting.
+                                            // This occurs in some versions of Safari before the oauth
+                                            // flow occurs, so we should keep polling in those cases.
                                         };
                                     } catch (e) {
                                         var okErrorMessages = [

--- a/yesgraph-invites.js
+++ b/yesgraph-invites.js
@@ -720,7 +720,7 @@
                                         // Handle case where auth failed
                                         contactsModal.closeModal();
                                         contactsModal.stopLoading();
-                                        flash.error();
+                                        flash.error(data.error);
                                         YesGraphAPI.error(data.error);
                                     });
                                 });
@@ -1253,18 +1253,16 @@
                                                 });
                                                 clearInterval(pollTimer);
                                                 win.close();
-                                            } else {
-                                                if (errorMessage === "Cannot read property 'URL' of undefined") {
-                                                    d.reject({
-                                                        "error": errorMessage
-                                                    });
-                                                };
-                                                else {
-                                                    d.reject({
-                                                        "error": "Google Oauth failed."
-                                                    });
-                                                };
+                                            } else if (errorMessage === "access_denied") {
+                                                d.reject({
+                                                    "error": "Access Denied"
+                                                });
+                                                clearInterval(pollTimer);
+                                                win.close();
                                             };
+                                            // If access was neither granted nor denied, keep waiting.
+                                            // This occurs in some versions of Safari before the oauth
+                                            // flow occurs, so we should keep polling in those cases.
                                         };
                                     } catch (e) {
                                         var okErrorMessages = [

--- a/yesgraph-invites.js
+++ b/yesgraph-invites.js
@@ -1,5 +1,5 @@
 ! function() {
-    var VERSION = "v0.0.2",
+    var VERSION = "v0.0.3",
         SDK_VERSION = "v0.0.2",
         CSS_VERSION = "v0.0.3",
         domReadyTimer = setInterval(function() {

--- a/yesgraph-invites.js
+++ b/yesgraph-invites.js
@@ -1255,9 +1255,13 @@
                                                 win.close();
                                             } else {
                                                 if (errorMessage === "Cannot read property 'URL' of undefined") {
-                                                    errorMessage = "Authorization failed."
                                                     d.reject({
                                                         "error": errorMessage
+                                                    });
+                                                };
+                                                else {
+                                                    d.reject({
+                                                        "error": "Google Oauth failed."
                                                     });
                                                 };
                                             };

--- a/yesgraph-invites.js
+++ b/yesgraph-invites.js
@@ -1244,9 +1244,6 @@
                                                 errorMessage = getUrlParam(responseUrl, "error"),
                                                 token = getUrlParam(responseUrl, "access_token");
 
-                                            clearInterval(pollTimer);
-                                            win.close();
-
                                             if (token) {
                                                 GMAIL_ACCESS_TOKEN = token;
                                                 d.resolve({
@@ -1254,14 +1251,15 @@
                                                     type: getUrlParam(responseUrl, "token_type"),
                                                     expires_in: getUrlParam(responseUrl, "expires_in")
                                                 });
-
+                                                clearInterval(pollTimer);
+                                                win.close();
                                             } else {
                                                 if (errorMessage === "Cannot read property 'URL' of undefined") {
                                                     errorMessage = "Authorization failed."
+                                                    d.reject({
+                                                        "error": errorMessage
+                                                    });
                                                 };
-                                                d.reject({
-                                                    "error": errorMessage
-                                                });
                                             };
                                         };
                                     } catch (e) {


### PR DESCRIPTION
#### What’s this PR do?
- fixes a bug in Google's oauth method `authPopup`. The method polls the url of the auth window and checks the following condition: `win.document.URL.indexOf(redirect) !== -1)` which returns a value if the window contains a string token matching the redirect url. On Safari, the Google OAuth popup's url changes to one containing the redirect url within a few milliseconds. This should only happen after submitting the signup form (or if you're already signed in).

This code change ensures that we don't close the auth window until we have the token, or have received a handled error. 
 
#### Where should the reviewer start?
Open Safari, and the demo_widget.html

#### How should this be manually tested?
click Gmail. Does it auth? 

