### PR TITLE
Fix auth error in minified code

### DIFF
--- a/src/dev/yesgraph-invites.js
+++ b/src/dev/yesgraph-invites.js
@@ -1150,12 +1150,9 @@
                                 }
                             } catch (e) {
                                 // Check the error message, then either keep waiting or reject with the error
-                                var okErrorMessages = [
-                                        "Cannot read property 'URL' of undefined",
-                                        "undefined is not an object (evaluating 'win.document.URL')",
-                                        'Permission denied to access property "document"'
-                                    ],
-                                    canIgnoreError = (okErrorMessages.indexOf(e.message) !== -1 || e.code === 18);
+                                var okErrorMessages = /(Cannot read property 'URL' of undefined|undefined is not an object \(evaluating '\w*.document.URL'\)|Permission denied to access property "document")/, // jshint ignore:line
+                                    canIgnoreError = (code === 18 || okErrorMessages.test(e.message));
+
                                 if (!canIgnoreError) {
                                     msg = canIgnoreError ? defaultAuthErrorMessage : e.message;
                                     d.reject({

--- a/src/yesgraph-invites.js
+++ b/src/yesgraph-invites.js
@@ -1150,12 +1150,9 @@
                                 }
                             } catch (e) {
                                 // Check the error message, then either keep waiting or reject with the error
-                                var okErrorMessages = [
-                                        "Cannot read property 'URL' of undefined",
-                                        "undefined is not an object (evaluating 'win.document.URL')",
-                                        'Permission denied to access property "document"'
-                                    ],
-                                    canIgnoreError = (okErrorMessages.indexOf(e.message) !== -1 || e.code === 18);
+                                var okErrorMessages = /(Cannot read property 'URL' of undefined|undefined is not an object \(evaluating '\w*.document.URL'\)|Permission denied to access property "document")/, // jshint ignore:line
+                                    canIgnoreError = (code === 18 || okErrorMessages.test(e.message));
+
                                 if (!canIgnoreError) {
                                     msg = canIgnoreError ? defaultAuthErrorMessage : e.message;
                                     d.reject({


### PR DESCRIPTION
#### What’s this PR do?
Fixes a bug that was occurring in minified versions of the code, such that the auth flow would fail preemptively with the message "Gmail Authorization Failed".

#### How should this be manually tested?
- Run `gulp` (this will create the most recent minified version)
- In src/demo_widget.html, update line 18 to use the minified code (dev/yesgraph-invites.**min**.js)
<img width="458" alt="screen shot 2016-07-15 at 11 48 19 am" src="https://cloud.githubusercontent.com/assets/10701968/16885170/26f9e5fe-4a82-11e6-8189-32cf12af4f63.png">
- Run `npm start`, then import your contacts from http://localhost:8000/src/demo_widget.html

#### What are the relevant tickets?
https://app.asana.com/0/59202558034519/155830436735737