### PR TITLE
Refactor raven dependency to fail gracefully; Add tests

### DIFF
--- a/karma-jquery1.7.conf.js
+++ b/karma-jquery1.7.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'http://code.jquery.com/jquery-1.7.2.js',
+      'http://code.jquery.com/jquery-1.7.2.min.js',
       'tests/fixtures.html',
       'tests/*.js',
       'src/dev/yesgraph-invites.css', 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,6 +16,10 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      // include jQuery explicitly, so that we can access it through
+      // the "$" variable in our tests (not "$j", which is the built-in
+      // jquery instance that comes with karma-jasmine-jquery)
+      'http://code.jquery.com/jquery-2.1.1.min.js',
       'tests/fixtures.html',
       'tests/*.js',
       'src/dev/yesgraph-invites.css', 

--- a/tests/test_api.js
+++ b/tests/test_api.js
@@ -35,7 +35,6 @@ describe('testAPI', function() {
     });
 
     describe("testInstall", function() {
-
         it('Should load YesGraphAPI.Raven', function() {
             // After Raven loads automatically, remove it and
             // check that we can replace it with loadRaven()
@@ -44,8 +43,8 @@ describe('testAPI', function() {
             YesGraphAPI.Raven = undefined
             expect(window.YesGraphAPI.Raven).not.toBeDefined();
 
-            spyOn($j, 'getScript').and.callFake(function(url){
-                var d = $j.Deferred();
+            spyOn($, 'getScript').and.callFake(function(url){
+                var d = $.Deferred();
                 YesGraphAPI.Raven = oldRaven;
                 d.resolve();
                 return d.promise();
@@ -53,7 +52,7 @@ describe('testAPI', function() {
 
             // Calling loadRaven() again should re-add it
             window.YesGraphAPI.utils.loadRaven();
-            expect($j.getScript).toHaveBeenCalled();
+            expect($.getScript).toHaveBeenCalled();
             expect(window.YesGraphAPI.Raven).toBeDefined();
         });
 
@@ -67,21 +66,21 @@ describe('testAPI', function() {
 
             // Force clientToken request to succeed
             spyOn(YesGraphAPI, "hitAPI").and.callFake(function() {
-                var d = $j.Deferred();
+                var d = $.Deferred();
                 d.resolve({ token: oldAPI.clientToken });
                 return d.promise();
             });
 
             // Force loadRaven() to fail
-            spyOn($j, 'getScript').and.callFake(function(){
-                var d = $j.Deferred();
+            spyOn($, 'getScript').and.callFake(function(){
+                var d = $.Deferred();
                 d.reject();
                 return d.promise();
             });
 
             YesGraphAPI.install({ app: oldAPI.app });
             expect(YesGraphAPI.hitAPI).toHaveBeenCalled();
-            expect($j.getScript).toHaveBeenCalled();
+            expect($.getScript).toHaveBeenCalled();
 
             // Check that it succesfully installed
             var interval = setInterval(function(){

--- a/tests/test_api.js
+++ b/tests/test_api.js
@@ -1,24 +1,24 @@
 describe('testAPI', function() {
 
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
     jasmine.getFixtures().fixturesPath = "base/tests";  // path to your templates
     jasmine.getFixtures().load('fixtures.html.js');   // load a template
 
-
     beforeEach(function (done) {
-        
         if (window.YesGraphAPI.isReady) {
             done();
-        }
-        else {
-            setTimeout(function() {
-                done();
-            }, 5000);
+        } else {
+            var interval = setInterval(function(){
+                if (window.YesGraphAPI.isReady) {
+                    clearInterval(interval);
+                    done();
+                }
+            }, 100);
         }
     });
     afterEach(function() {
-        //jasmine.getFixtures().cleanUp();
-        ///jasmine.getFixtures().clearCache();
+        // jasmine.getFixtures().cleanUp();
+        // jasmine.getFixtures().clearCache();
     });
 
     it('Should have yesgraph', function() {
@@ -26,8 +26,76 @@ describe('testAPI', function() {
         expect(window.YesGraphAPI).toBeDefined();
     });
 
-    it('Should have YesGraphAPI.Raven', function() {
-        expect(window.YesGraphAPI.Raven).toBeDefined();
+    it('Should be removed by YesGraphAPI.noConflict', function() {
+        expect(window.YesGraphAPI).toBeDefined();
+        var _api = window.YesGraphAPI.noConflict();
+        expect(window.YesGraphAPI).not.toBeDefined();
+        window.YesGraphAPI = _api;
+        expect(window.YesGraphAPI).toBeDefined();
+    });
+
+    describe("testInstall", function() {
+
+        it('Should load YesGraphAPI.Raven', function() {
+            // After Raven loads automatically, remove it and
+            // check that we can replace it with loadRaven()
+            expect(window.YesGraphAPI.Raven).toBeDefined();
+            var oldRaven = YesGraphAPI.Raven;
+            YesGraphAPI.Raven = undefined
+            expect(window.YesGraphAPI.Raven).not.toBeDefined();
+
+            spyOn($j, 'getScript').and.callFake(function(url){
+                var d = $j.Deferred();
+                YesGraphAPI.Raven = oldRaven;
+                d.resolve();
+                return d.promise();
+            });
+
+            // Calling loadRaven() again should re-add it
+            window.YesGraphAPI.utils.loadRaven();
+            expect($j.getScript).toHaveBeenCalled();
+            expect(window.YesGraphAPI.Raven).toBeDefined();
+        });
+
+        it('Should install successfully even if Raven fails', function(done) {
+            // Remove the YesGraphAPI object
+            var oldAPI = YesGraphAPI.noConflict();
+            expect(window.YesGraphAPI).not.toBeDefined();
+
+            // Try to re-install
+            window.YesGraphAPI = new YesGraphAPIConstructor();
+
+            // Force clientToken request to succeed
+            spyOn(YesGraphAPI, "hitAPI").and.callFake(function() {
+                var d = $j.Deferred();
+                d.resolve({ token: oldAPI.clientToken });
+                return d.promise();
+            });
+
+            // Force loadRaven() to fail
+            spyOn($j, 'getScript').and.callFake(function(){
+                var d = $j.Deferred();
+                d.reject();
+                return d.promise();
+            });
+
+            YesGraphAPI.install({ app: oldAPI.app });
+            expect(YesGraphAPI.hitAPI).toHaveBeenCalled();
+            expect($j.getScript).toHaveBeenCalled();
+
+            // Check that it succesfully installed
+            var interval = setInterval(function(){
+                if (YesGraphAPI.isReady) {
+                    clearInterval(interval);
+                    done();
+                }
+            }, 100);
+
+            // Cleanup! We should replace the original YesGraphAPI object
+            // because the Superwidget is associated with that instance
+            window.YesGraphAPI.noConflict();
+            window.YesGraphAPI = oldAPI;
+        });
     });
 
     describe("testEndpoints", function() {
@@ -95,22 +163,34 @@ describe('testAPI', function() {
     });
 
     describe("testAnalyticsManager", function() {
+        beforeEach(function (done) {
+            if (YesGraphAPI.AnalyticsManager.isReady) {
+                done();
+            } else {
+                var interval = setInterval(function(){
+                    if (YesGraphAPI.AnalyticsManager.isReady) {
+                        clearInterval(interval);
+                        done();
+                    }
+                }, 100);
+            }
+        });
 
         it('Should have YesGraphAPI.AnalyticsManager', function() {
-            expect(window.YesGraphAPI.AnalyticsManager).toBeDefined();
+            expect(YesGraphAPI.AnalyticsManager).toBeDefined();
         });
 
         it('Should hit analytics endpoint with events', function() {
-            spyOn(window.YesGraphAPI, 'hitAPI');
-            window.YesGraphAPI.AnalyticsManager.log("Test Event");
-            expect(window.YesGraphAPI.hitAPI).toHaveBeenCalled();
+            spyOn(YesGraphAPI, 'hitAPI');
+            YesGraphAPI.AnalyticsManager.log("Test Event");
+            expect(YesGraphAPI.hitAPI).toHaveBeenCalled();
         });
 
         it('Should not hit analytics endpoint without events', function() {
-            spyOn(window.YesGraphAPI, 'hitAPI');
-            window.YesGraphAPI.AnalyticsManager.postponed = []; // Clear any postponed events
-            window.YesGraphAPI.AnalyticsManager.log(); // There should be no events to log
-            expect(window.YesGraphAPI.hitAPI).not.toHaveBeenCalled();
+            spyOn(YesGraphAPI, 'hitAPI');
+            YesGraphAPI.AnalyticsManager.postponed = []; // Clear any postponed events
+            YesGraphAPI.AnalyticsManager.log(); // There should be no events to log
+            expect(YesGraphAPI.hitAPI).not.toHaveBeenCalled();
         });
     });
 
@@ -143,14 +223,6 @@ describe('testAPI', function() {
             }).not.toThrow();
 
             window.console = _console;
-        });
-
-        it('Should be removed by YesGraphAPI.noConflict', function() {
-            expect(window.YesGraphAPI).toBeDefined();
-            var _api = window.YesGraphAPI.noConflict();
-            expect(window.YesGraphAPI).not.toBeDefined();
-            window.YesGraphAPI = _api;
-            expect(window.YesGraphAPI).toBeDefined();
         });
     });
 });

--- a/tests/test_superwidget.js
+++ b/tests/test_superwidget.js
@@ -11,7 +11,13 @@ describe('testSuperwidgetUI', function() {
             finishPrep();
         }
         else {
-            setTimeout(finishPrep, 1000);
+            var interval = setInterval(function(){
+                if (window.YesGraphAPI.isReady
+                    && window.YesGraphAPI.Superwidget.isReady) {
+                    clearInterval(interval);
+                    finishPrep();
+                }
+            }, 100);
         }
         function finishPrep(){
             widget = window.YesGraphAPI.Superwidget;
@@ -21,8 +27,8 @@ describe('testSuperwidgetUI', function() {
     });
 
     afterEach(function() {
-        //jasmine.getFixtures().cleanUp();
-        ///jasmine.getFixtures().clearCache();
+        // jasmine.getFixtures().cleanUp();
+        // jasmine.getFixtures().clearCache();
     });
 
     describe('testWidgetContainer', function(){


### PR DESCRIPTION
### What’s this PR do?
Refactors the Raven dependency to (1) fail gracefully if it gets blocked by an ad-blocker, and (2) be more testable.

### Any background context you want to provide?
Previously, the `YesGraphAPI.install()` method would only set `YesGraphAPI.isReady = true` once Raven successfully loaded. However, certain ad-blockers will prevent Raven from loading. In that case we should log an analytics event but still complete the installation.

### How should this be manually tested?
I've updated the tests to address these changes, so you can just run `npm test` 🙂

### What are the relevant tickets?
- [Refactor highly nested Superwidget code](https://app.asana.com/0/59202558034519/162364139954353)
- [Refactor Raven dependency to handle ad blockers](https://app.asana.com/0/59202558034519/162814167478518)