### PR TITLE
Allow whitespace as a delimiter between multiple emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "brfs": "^1.4.3",
-    "concurrently": "^2.2.0",
     "del": "^2.2.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
@@ -61,7 +60,7 @@
     "build": "gulp build",
     "lint": "gulp lint",
     "clean": "gulp clean",
-    "start": "echo \"Starting server at localhost:8080\"; concurrently -k \"python3 -m http.server 8080\" \"gulp watch\""
+    "start": "echo \"Starting server at localhost:8080\"; python3 -m http.server 8080;"
   },
   "repository": {
     "type": "git",

--- a/src/dev/yesgraph-invites.js
+++ b/src/dev/yesgraph-invites.js
@@ -1209,7 +1209,7 @@
                     email;
 
                 if (elem.is("textarea")) {
-                    emails = elem.val().split(/\s+|,/);
+                    emails = elem.val().split(/\s+|,|;/);
                     emails.forEach(function (email, index, array){
                         email = email.replace(/^\s+|\s+$/g, ''); // strip whitespace
                         if (email) {

--- a/src/dev/yesgraph-invites.js
+++ b/src/dev/yesgraph-invites.js
@@ -1209,7 +1209,7 @@
                     email;
 
                 if (elem.is("textarea")) {
-                    emails = elem.val().split(",");
+                    emails = elem.val().split(/\s+|,/);
                     emails.forEach(function (email, index, array){
                         email = email.replace(/^\s+|\s+$/g, ''); // strip whitespace
                         if (email) {

--- a/tests/test_superwidget.js
+++ b/tests/test_superwidget.js
@@ -144,6 +144,24 @@ describe('testSuperwidgetUI', function() {
                 return recipients.length;
             }()).toEqual(0); // No valid recipients should be returned
         });
+
+        it("Should identify multiple email recipients", function() {
+            var inputField = widget.container.find(".yes-manual-input-field");
+            var emails = ["valid+1@email.com", "valid+2@email.com", "valid+3@email.com"];
+            var recipients;
+
+            inputField.val(emails.join(",")); // separated by comma
+            recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
+            expect(recipients.length).toEqual(emails.length);
+
+            inputField.val(emails.join(" ")); // separated by space
+            recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
+            expect(recipients.length).toEqual(emails.length);
+
+            inputField.val(emails.join("\n")); // separated by newline
+            recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
+            expect(recipients.length).toEqual(emails.length);
+        });
     });
 
     describe('testContactsModal', function(){

--- a/tests/test_superwidget.js
+++ b/tests/test_superwidget.js
@@ -154,11 +154,19 @@ describe('testSuperwidgetUI', function() {
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
 
+            inputField.val(emails.join(";")); // separated by semicolon
+            recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
+            expect(recipients.length).toEqual(emails.length);
+
             inputField.val(emails.join(" ")); // separated by space
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
 
             inputField.val(emails.join("\n")); // separated by newline
+            recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
+            expect(recipients.length).toEqual(emails.length);
+
+            inputField.val(emails.join("\n, ")); // combined delimiters
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
         });


### PR DESCRIPTION
### What’s this PR do?
Previously to enter multiple emails in the superwidget, they had to be separated by commas. Now they can be separated by commas or whitespace.

### How should this be manually tested?
Run `gulp test`

### What are the relevant tickets?
[Accept whitespace or commas as Superwidget email delimiters](https://app.asana.com/0/59202558034519/174289037462813)

### Does the knowledge base need an update?
No, but we should notify Alireza when this goes live.