### PR TITLE
Fix oauth bug (only in Chrome on iPhone 6)

### DIFF
--- a/demo_widget.html
+++ b/demo_widget.html
@@ -9,8 +9,7 @@
 
 <span id="yesgraph" class="yesgraph-invites"
       data-app="YesGraph" data-email="some@email.com"
-      data-name="Some Name" data-show-contacts="false"
-      data-foo="bar">
+      data-name="Some Name" data-foo="bar">
 </span>
 
 <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>

--- a/src/dev/yesgraph-invites.js
+++ b/src/dev/yesgraph-invites.js
@@ -1093,9 +1093,9 @@
                     var msg, authCode, accessToken, errorMsg, responseUrl;
                     var defaultAuthErrorMessage = self.service.name + " Authorization Failed";
                     var oauthInfo = self.getOAuthInfo(self.service);
-                    var popup = open(oauthInfo.url, self.service.name + " Authorization", service.popupSize);
+                    var popup = open(oauthInfo.url, "_blank", service.popupSize);
                     var popupTimer = setInterval(function() {
-                        if (popup && popup.closed === true) {
+                        if (typeof popup !== "object" || popup.closed === true) {
                             d.reject({ error: defaultAuthErrorMessage });
                             clearInterval(popupTimer);
                             return;
@@ -1124,14 +1124,13 @@
                                 }
                                 clearInterval(popupTimer);
                                 if (popup) {
-                                    popup.close();    
+                                    popup.close();
                                 }
                             }
                         } catch (e) {
                             // Check the error message, then either keep waiting or reject with the error
                             var okErrorMessages = /(Cannot read property 'URL' of undefined|undefined is not an object \(evaluating '\w*.document.URL'\)|Permission denied to access property "\w*")/, // jshint ignore:line
                                 canIgnoreError = (e.code === 18 || okErrorMessages.test(e.message));
-
                             if (!canIgnoreError) {
                                 msg = canIgnoreError ? defaultAuthErrorMessage : e.message;
                                 d.reject({
@@ -1140,7 +1139,7 @@
                                 YesGraphAPI.utils.error(msg, false);
                                 clearInterval(popupTimer);
                                 if (popup) {
-                                    popup.close();    
+                                    popup.close();
                                 }
                             }
                         }


### PR DESCRIPTION
### What’s this PR do?
This PR fixes a bug appearing in Chrome on the iPhone 6, whereby the oauth flow never fully finishes.

Users could go through the authorization parts, but the Superwidget failed to retrieve the resulting data & close the window. This is because Chrome doesn't support "popups", and it considers a window opened by `window.open(url, title)` to be a popup if and only if the `title` parameter is not "_blank". Because we were using "Google Authorization" as the title, it was considered a popup and it's value was `undefined`. Switching the title to "_blank" resolved the issue.

[This StackOverflow question](http://stackoverflow.com/a/30226002/6513736) lead me to the answer, referencing [this Chromium bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=136610#c68).

### Reproducing the Problem
To reproduce the problem, open the demo page in Chrome on an iPhone 6 using BrowserStack:
https://www.browserstack.com/start#os=iOS&os_version=8.0&device=iPhone+6&device_browser=chrome&zoom_to_fit=true&full_screen=true&url=http%3A%2F%2Fyesgraph.com%2Fdemo&speed=1&host_ports=google.com%2C80%2C0

Try authing Gmail, and you should notice that there are 2 tabs open at the end of the auth flow, and your contacts are never displayed:
<img width="337" alt="2tabs" src="https://cloud.githubusercontent.com/assets/10701968/18802031/4a6c69e4-819b-11e6-947f-c32928c8caeb.png">

### Testing the Solution

I use [LocalTunnel](https://localtunnel.github.io/www/) to access localhost from within BrowserStack. If you don't have it installed, you can get it with `npm install -g localtunnel`

1. Run `npm start` to run the server on localhost:8080
2. Run `lt --port 8080` to get a public URL for your local server
<img width="386" alt="screen shot 2016-09-23 at 2 42 12 pm" src="https://cloud.githubusercontent.com/assets/10701968/18802143/f5f8ada4-819b-11e6-825f-f3390dc39610.png">
3. Navigate to that URL (with the path /demo_widget.html) from Chrome on the BrowserStack iPhone 6, and try authorizing. It should complete the flow and display your contacts as usual 🐳

### What are the relevant tickets?
[Bugfix: Superwidget OAuth fails in Chrome on iPhone 6](https://app.asana.com/0/59202558034519/186252487870940/f)
