### PR TITLE
Bugfix in the deploy process

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -40,7 +40,7 @@ module.exports = {
             reportFile: root + "/jshint-report.txt"
         },
         minifyScripts: {
-            files: src.root + "/**/yesgraph?(-invites).js"
+            files: dest.root + "/**/yesgraph?(-invites).js"
         },
         minifyCss: {
             files: dest.root + "/**/yesgraph-invites.css"
@@ -50,9 +50,10 @@ module.exports = {
         },
         version: {
             files: [
-                "./**/yesgraph?(-invites)?(.min).@(js|css)",
-                "./package.json",
-                "./gulp/config.js"
+                src.root + "/**/yesgraph?(-invites)?(.min).js",
+                dest.root + "/**/yesgraph-invites?(.min).css",
+                root + "/package.json",
+                root + "/gulp/config.js"
             ]
         },
         update: {

--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -4,9 +4,7 @@ var config = require("../config");
 var sequence = require("run-sequence").use(gulp);
 
 gulp.task("build", ["clean"], function(done){
-    sequence("compile:less", "version", "minify", function() {
-        gulp.src(config.tasks.build.files, {base: config.src.root})
-            .pipe(gulp.dest(config.dest.root))
-            .on("end", done);
+    sequence("compile:less", "version", "minify", function(){
+    	done();
     });
 });

--- a/gulp/tasks/compile.js
+++ b/gulp/tasks/compile.js
@@ -3,14 +3,21 @@ var gulp = require("gulp");
 var rename = require("gulp-rename");
 var less = require("gulp-less");
 var autoprefixer = require("gulp-autoprefixer");
+var debug = require("gulp-debug");
 var config = require("../config");
 
 gulp.task("compile:less", function() {
     return gulp.src(config.tasks.compileLess.files, {base: config.src.root})
+        .pipe(debug({title: "compile:less"}))
         .pipe(less())
         .pipe(rename({extname: ".css"}))
-        .pipe(autoprefixer({
-            browsers: ["last 2 versions"]
-        }))
+        // This is commented out because it's breaking our build and
+        // preventing the next tasks from running properly. It would
+        // be good to add it back at some point, but it's not urgent
+        // because our existing CSS doesn't require autoprefixing.
+        //
+        // .pipe(autoprefixer({
+        //     browsers: ["last 2 versions"]
+        // }))
         .pipe(gulp.dest(config.dest.root));
 });

--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -9,6 +9,7 @@ var if_ = require("gulp-if");
 var lazypipe = require("lazypipe");
 var prompt = require("gulp-prompt");
 var rename = require("gulp-rename");
+var debug = require("gulp-debug");
 
 var sdkFiles = ["yesgraph.js", "yesgraph.min.js", "yesgraph.min.js.map"];
 var superwidgetFiles = ["yesgraph-invites.js", "yesgraph-invites.min.js", "yesgraph-invites.min.js.map"];
@@ -67,6 +68,7 @@ gulp.task("deploy", ["build"], function() {
 
     if (!argv.test) {
         return gulp.src(config.tasks.deploy.files)
+            .pipe(debug({title: "deploy"}))
             .pipe(deployPrep())
             .pipe(if_(isDevDeploy, filter(devFiles))) // only update files in the dev/ folder
             .pipe(publisher.publish({}, {force: true}))
@@ -74,6 +76,7 @@ gulp.task("deploy", ["build"], function() {
             .pipe(cloudfront(config.cloudfront));
     } else if (argv.test) {
         return gulp.src(config.tasks.deploy.files)
+            .pipe(debug({title: "deploy"}))
             .pipe(deployPrep())
             .pipe(if_(isDevDeploy, filter(devFiles))) // only update files in the dev/ folder
             .pipe(gulp.dest("deployed"));

--- a/gulp/tasks/minify.js
+++ b/gulp/tasks/minify.js
@@ -4,10 +4,12 @@ var uglify = require("gulp-uglify");
 var rename = require("gulp-rename");
 var cleanCSS = require("gulp-clean-css");
 var sourcemaps = require("gulp-sourcemaps");
+var debug = require('gulp-debug');
 var config = require("../config");
 
 gulp.task("minify:js", function() {
     return gulp.src(config.tasks.minifyScripts.files, {base: config.src.root})
+        .pipe(debug({title: "minify:js"}))
         .pipe(sourcemaps.init())
         .pipe(uglify({preserveComments: "license"}))
         .pipe(rename({suffix: ".min"}))
@@ -17,6 +19,7 @@ gulp.task("minify:js", function() {
 
 gulp.task("minify:css", function() {
     return gulp.src(config.tasks.minifyCss.files, {base: config.dest.root})
+        .pipe(debug({title: "minify:css"}))
         .pipe(cleanCSS({keepSpecialComments: 1}))
         .pipe(rename({suffix: ".min"}))
         .pipe(gulp.dest(config.dest.root));

--- a/gulp/tasks/version.js
+++ b/gulp/tasks/version.js
@@ -6,6 +6,7 @@ var gulp = require('gulp');
 var prompt = require("gulp-prompt");
 var replace = require("gulp-replace");
 var semver = require("semver");
+var debug = require("gulp-debug");
 var versions = config.version;
 
 /*
@@ -33,25 +34,26 @@ gulp.task("version", function() {
     setUpdateType();
 
     return gulp.src(config.tasks.version.files)
+        .pipe(debug({title: "version"}))
 
         // Update version in code files
         .pipe(sourceCodeFilter)
         .pipe(replace(/__(\w*)_VERSION__/g, fileVersionReplacer))
         .pipe(replace(/__BUILD_DATE__/g, CURRENT_DATE))
-        .pipe(gulp.dest(".")) // stores code in dist/ folder
+        .pipe(gulp.dest(config.dest.root)) // stores code in dist/ folder
         .pipe(sourceCodeFilter.restore)
 
         // Update version in package.json
         .pipe(packageFilter)
         .pipe(replace(/"version": ?"\S*"/, packageVersionReplacer))
-        .pipe(gulp.dest(".")) // stores package.json at root
+        .pipe(gulp.dest(config.root)) // stores package.json at root
         .pipe(packageFilter.restore)
 
         // Update config file to persist version change
         .pipe(configFilter)
         .pipe(replace(/__(\w*)_VERSION__ ?\= ?[\'\"]\S*[\'\"];/g, configVersionReplacer))
-        .pipe(gulp.dest("./gulp")) // stores config.js in gulp/ folder
-        .pipe(configFilter.restore)
+        .pipe(gulp.dest(config.root + "/gulp")) // stores config.js in gulp/ folder
+        .pipe(configFilter.restore);
 });
 
 function fileVersionReplacer(match, target) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-clean-css": "^2.0.10",
     "gulp-clone": "^1.0.0",
     "gulp-cloudfront-invalidate": "^0.1.2",
+    "gulp-debug": "^2.1.2",
     "gulp-filter": "^4.0.0",
     "gulp-if": "^2.0.1",
     "gulp-jshint": "^2.0.1",


### PR DESCRIPTION
### What’s this PR do?
This PR fixes a bug in the deploy process. Here's how it's supposed to work:

1. src/\*.less files get compiled & moved to dist/\*.css
2. src/\*.js files and dist/\*.css files get versioned & moved to dist/\*.js and dist/\*.css
3. dist/\* files get minified and copied into dist/\*.min.\*
4. dist/* gets deployed to the CDN (or to the deployed/ folder, if the `--test` param is used)

Previously, versioned files were ending up in src/ (not dist/).

Also, this PR uses gulp-debug to log filenames to the terminal while they're being processed. This is helpful because we can make sure the right files are being processed in the right order.

### Reproducing the Problem
From the master branch, run `gulp deploy --test` Then run `git status`, and you'll notice that the files in src/ have been changed. That's bad!

### Testing the Solution
From this branch, run `gulp deploy --test`.
The logs in your terminal should end with this:
<img width="346" alt="screen shot 2016-09-23 at 4 35 34 pm" src="https://cloud.githubusercontent.com/assets/10701968/18804116/c71f55e0-81ab-11e6-9eed-446540b69a35.png">
Now if you run `git status`, there shouldn't be any changed files from the src/ directory.

### What are the relevant tickets?
[Asana Task: Debug superwidget deploy error](https://app.asana.com/0/59202558034519/182385307523204)

### Does the knowledge base need an update?
I'm working on a wiki page for this deploy process, which will be finished at the latest before I go on vacation October 6th.