### PR TITLE
Enable parsing emails & names copied from Gmail

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -46,7 +46,10 @@ module.exports = {
             files: dest.root + "/**/yesgraph-invites.css"
         },
         watch: {
-            files: src.root + "/**/yesgraph*"
+            files: {
+                js: src.dev + "/yesgraph?(-invites).js",
+                less: src.dev + "/yesgraph-invites.less"
+            }
         },
         version: {
             files: [

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -2,6 +2,11 @@
 var gulp = require("gulp");
 var config = require("../config");
 
+gulp.task("_js", ["version"], function(){
+	return gulp.start("minify:js");
+});
+
 gulp.task("watch", function(){
-    return gulp.watch(config.tasks.watch.files, ["build"]);
+    gulp.watch(config.tasks.watch.files.js, ["_js"]);
+    gulp.watch(config.tasks.watch.files.less, ["compile:less"]);
 });

--- a/src/dev/yesgraph-invites.js
+++ b/src/dev/yesgraph-invites.js
@@ -1212,21 +1212,22 @@
                     recipient,
                     emails,
                     email;
-
                 if (elem.is("textarea")) {
-                    emails = elem.val().split(/\s+|,|;/);
-                    emails.forEach(function (email, index, array){
-                        email = email.replace(/^\s+|\s+$/g, ''); // strip whitespace
-                        if (email) {
-                            if (isValidEmail(email)) {
-                                recipients.push({
-                                    "email": email
-                                });
-                            } else {
-                                flash.error('Invalid email "' + email + '".');
-                            }
-                        }
-                    });
+                    var text = elem.val();
+                    var regex = /([^<>\s,.;]*@[^<>\s,.;]*\.[^<>\s,.;]*)/gi;
+                    var match, lastMatchEnd = 0;
+                    while(true) {
+                        match = regex.exec(text);
+                        if (!match) break;
+                        var name = text.slice(lastMatchEnd, match.index)
+                                       .replace(/<|>|,|;/g, "")  // strip punctuation
+                                       .replace(/^\s+|\s+$/g, "");  // strip whitespace
+                        recipients.push({
+                            name: name || undefined,
+                            email: match[0] || undefined
+                        });
+                        lastMatchEnd = regex.lastIndex;
+                    }
                     return recipients;
 
                 } else {

--- a/tests/test_superwidget.js
+++ b/tests/test_superwidget.js
@@ -153,22 +153,77 @@ describe('testSuperwidgetUI', function() {
             inputField.val(emails.join(",")); // separated by comma
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
+            recipients.forEach(function(recipient){
+                if (recipient.email === "valid+1@email.com") {
+                    expect(recipient.name).toEqual("Valid Email 1");
+                } else if (recipient.email === "valid+2@email.com") {
+                    expect(recipient.name).not.toBeDefined();
+                } else if (recipient.email === "valid+3@email.com") {
+                    expect(recipient.name).toEqual("Valid Email 3");
+                } else {
+                    expect(true).toEqual(false);  // fail the test
+                }
+            });
 
             inputField.val(emails.join(";")); // separated by semicolon
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
+            recipients.forEach(function(recipient){
+                if (recipient.email === "valid+1@email.com") {
+                    expect(recipient.name).toEqual("Valid Email 1");
+                } else if (recipient.email === "valid+2@email.com") {
+                    expect(recipient.name).not.toBeDefined();
+                } else if (recipient.email === "valid+3@email.com") {
+                    expect(recipient.name).toEqual("Valid Email 3");
+                } else {
+                    expect(true).toEqual(false);  // fail the test
+                }
+            });
 
             inputField.val(emails.join(" ")); // separated by space
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
+            recipients.forEach(function(recipient){
+                if (recipient.email === "valid+1@email.com") {
+                    expect(recipient.name).toEqual("Valid Email 1");
+                } else if (recipient.email === "valid+2@email.com") {
+                    expect(recipient.name).not.toBeDefined();
+                } else if (recipient.email === "valid+3@email.com") {
+                    expect(recipient.name).toEqual("Valid Email 3");
+                } else {
+                    expect(true).toEqual(false);  // fail the test
+                }
+            });
 
             inputField.val(emails.join("\n")); // separated by newline
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
+            recipients.forEach(function(recipient){
+                if (recipient.email === "valid+1@email.com") {
+                    expect(recipient.name).toEqual("Valid Email 1");
+                } else if (recipient.email === "valid+2@email.com") {
+                    expect(recipient.name).not.toBeDefined();
+                } else if (recipient.email === "valid+3@email.com") {
+                    expect(recipient.name).toEqual("Valid Email 3");
+                } else {
+                    expect(true).toEqual(false);  // fail the test
+                }
+            });
 
             inputField.val(emails.join("\n, ")); // combined delimiters
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
+            recipients.forEach(function(recipient){
+                if (recipient.email === "valid+1@email.com") {
+                    expect(recipient.name).toEqual("Valid Email 1");
+                } else if (recipient.email === "valid+2@email.com") {
+                    expect(recipient.name).not.toBeDefined();
+                } else if (recipient.email === "valid+3@email.com") {
+                    expect(recipient.name).toEqual("Valid Email 3");
+                } else {
+                    expect(true).toEqual(false);  // fail the test
+                }
+            });
         });
     });
 

--- a/tests/test_superwidget.js
+++ b/tests/test_superwidget.js
@@ -147,7 +147,7 @@ describe('testSuperwidgetUI', function() {
 
         it("Should identify multiple email recipients", function() {
             var inputField = widget.container.find(".yes-manual-input-field");
-            var emails = ["valid+1@email.com", "valid+2@email.com", "valid+3@email.com"];
+            var emails = ["Valid Email 1 <valid+1@email.com>", "valid+2@email.com", "Valid Email 3 <valid+3@email.com>"];
             var recipients;
 
             inputField.val(emails.join(",")); // separated by comma


### PR DESCRIPTION
### What’s this PR do?
Previously the Superwidget could parse emails separated by whitespace or punctuation:
```
some@email.com; some+other@email.com
some+third@email.com
```
 But not emails  copied & pasted directly from Gmail, which come in this format:
```
Some Name <some@email.com>
```

This PR makes email parsing more robust, so we can handle that format, or a combination of formats:
```
some@email.com;
Carolyn Lee <carolyn@yesgraph.com> some+other@email.com
```

I've also made a small change to the gulp "watch" task, which makes development easier, but is never run in production.

### Where should the reviewer start?
Start with the changes in src/dev/yesgraph-invites.js

### How should this be manually tested?
I've updated the tests, so just run `gulp test`

### What are the relevant tickets?
[Asana Task: Parse names & emails copied from Gmail](https://app.asana.com/0/59202558034519/186268521780747)