### PR TITLE
Error handling

### DIFF
--- a/demo_widget.html
+++ b/demo_widget.html
@@ -30,6 +30,13 @@ $(document).on("set.yesgraph.recipients", function(evt, recipients){
     // Do something with the recipients
     console.debug("Added " + recipients.length + " recipients.");
 });
+$(document).on("completed.yesgraph.oauth", function(evt, service, err){
+  	if (err) {
+  		console.debug(service, "oauth failed", err);
+  	} else {
+  		console.debug(service, "oauth succeeded");
+  	}
+});
 </script>
 </div>
 </body>

--- a/src/dev/yesgraph-invites.js
+++ b/src/dev/yesgraph-invites.js
@@ -1134,7 +1134,12 @@
                                 }
                             }
                         } catch (e) {
-                            // Check the error message, then either keep waiting or reject with the error
+                            /* This timer is checking periodically to see if the user has finished the auth flow.
+                             * If the auth flow is still in progress, the check itsef will throw an error, because
+                             * the auth page is on a different domain. We should catch and ignore those errors.
+                             * 
+                             * This `catch` block should decide whether to ignore the error or not.
+                             */
                             var okErrorMessages = /(Cannot read property\w*|undefined is not an object \(evaluating \w*\)|Permission denied\w*)/, // jshint ignore:line
                                 canIgnoreError = (e.code === 18 || okErrorMessages.test(e.message));
                             if (!canIgnoreError) {

--- a/src/dev/yesgraph-invites.js
+++ b/src/dev/yesgraph-invites.js
@@ -702,7 +702,8 @@
                         }).prop("placeholder", widgetCopy.manual_input_placeholder || "Enter emails here"),
                         manualInputSubmit = $('<button>', {
                             "text": widgetCopy.manualInputSendBtn || "Add Emails",
-                            "class": "yes-default-btn yes-manual-input-submit"
+                            "class": "yes-default-btn yes-manual-input-submit",
+                            "type": "button"
                         }),
                         includeGoogle = OPTIONS.settings.oauthServices.indexOf("google") !== -1,
                         includeOutlook = OPTIONS.settings.oauthServices.indexOf("outlook") !== -1,
@@ -1054,6 +1055,7 @@
                         if (YesGraphAPI.settings.showContacts !== false) {
                             contactsModal.loading();
                         }
+                        $(document).trigger(YesGraphAPI.events.COMPLETED_OAUTH, [self.service.id, null]);
                         self.fetchContacts(authData).done(function(response){
                             // Trigger DOM event "imported.yesgraph.contacts"
                             if (response.data.source === "gmail") {
@@ -1069,7 +1071,10 @@
                             contactsModal.closeModal();
                             d.reject(err);
                         });
-                    }).fail(d.reject);
+                    }).fail(function(err) {
+                        $(document).trigger(YesGraphAPI.events.COMPLETED_OAUTH, [self.service.id, err]);
+                        d.reject(err);
+                    });
                     return d.promise();
                 };
 
@@ -1193,7 +1198,8 @@
                         YesGraphAPI.events = $.extend(YesGraphAPI.events, {
                             SET_RECIPIENTS: "set.yesgraph.recipients",
                             IMPORTED_CONTACTS: "imported.yesgraph.contacts",
-                            INSTALLED_SUPERWIDGET: "installed.yesgraph.superwidget"
+                            INSTALLED_SUPERWIDGET: "installed.yesgraph.superwidget",
+                            COMPLETED_OAUTH: "completed.yesgraph.oauth"
                         });
                         d.resolve();
                     }

--- a/src/dev/yesgraph-invites.js
+++ b/src/dev/yesgraph-invites.js
@@ -880,7 +880,8 @@
                             btnClass = "yes-default-btn yes-contact-import-btn yes-contact-import-btn-" + service.id,
                             btn = $("<button>", {
                                 "class": btnClass,
-                                "title": service.name
+                                "title": service.name,
+                                "type": "button"
                             }).append(outerWrapper);
 
                         if (btnCount > 3) {
@@ -1129,7 +1130,7 @@
                             }
                         } catch (e) {
                             // Check the error message, then either keep waiting or reject with the error
-                            var okErrorMessages = /(Cannot read property 'URL' of undefined|undefined is not an object \(evaluating '\w*.document.URL'\)|Permission denied to access property "\w*")/, // jshint ignore:line
+                            var okErrorMessages = /(Cannot read property\w*|undefined is not an object \(evaluating \w*\)|Permission denied\w*)/, // jshint ignore:line
                                 canIgnoreError = (e.code === 18 || okErrorMessages.test(e.message));
                             if (!canIgnoreError) {
                                 msg = canIgnoreError ? defaultAuthErrorMessage : e.message;
@@ -1137,6 +1138,9 @@
                                     error: msg
                                 });
                                 YesGraphAPI.utils.error(msg, false);
+                                if (YesGraphAPI.Raven) {
+                                    YesGraphAPI.Raven.captureException(e);
+                                }
                                 clearInterval(popupTimer);
                                 if (popup) {
                                     popup.close();

--- a/tests/test_superwidget.js
+++ b/tests/test_superwidget.js
@@ -154,7 +154,6 @@ describe('testSuperwidgetUI', function() {
                         }
                     }
                 };
-                console.warn(url);
                 d.resolve(fakeRespone);
                 return d.promise();
             });

--- a/tests/test_superwidget.js
+++ b/tests/test_superwidget.js
@@ -160,10 +160,11 @@ describe('testSuperwidgetUI', function() {
 
             // Click the contact import button, and check that the auth flow succeeds
             widget.container.find(".yes-contact-import-btn-google").click();
-            $(document).on("imported.yesgraph.contacts", function() {
-                // Check that the popup was opened
-                expect(window.open).toHaveBeenCalled();
 
+            // Check that the popup was opened
+            expect(window.open).toHaveBeenCalled();
+
+            $(document).on("imported.yesgraph.contacts", function() {
                 // Among the API calls made, one should be to the /oauth endpoint
                 var oauthEndpointCall;
                 YesGraphAPI.hitAPI.calls.all().forEach(function(call) {

--- a/tests/test_superwidget.js
+++ b/tests/test_superwidget.js
@@ -124,6 +124,60 @@ describe('testSuperwidgetUI', function() {
         });
     });
 
+    describe("testOAuthFlow", function() {
+        it("Should succesfully complete the OAuth flow", function(done) {
+
+            // When we open the popup, change the URL so we bypass the authorization process
+            var realOpen = window.open;
+            spyOn(window, "open").and.callFake(function(url){
+                var url = window.location.href + "#code=TEST";
+                return realOpen(url, "_blank");
+            });
+            var realHitAPI = YesGraphAPI.hitAPI;
+            spyOn(YesGraphAPI, "hitAPI").and.callFake(function(url) {
+                var d = $.Deferred();
+                var fakeRespone = {
+                    message: "Address book for TEST added.",
+                    batch_id: "TEST",
+                    meta: {
+                        app_name: "TEST",
+                        user_id: "TEST",
+                        total_count: 0,
+                        time: 1.5
+                    },
+                    data: {
+                        ranked_contacts: [],
+                        source: {
+                            name: "Test User",
+                            email: "test@user.com",
+                            type: "gmail"
+                        }
+                    }
+                };
+                console.warn(url);
+                d.resolve(fakeRespone);
+                return d.promise();
+            });
+
+            // Click the contact import button, and check that the auth flow succeeds
+            widget.container.find(".yes-contact-import-btn-google").click();
+            $(document).on("imported.yesgraph.contacts", function() {
+                // Check that the popup was opened
+                expect(window.open).toHaveBeenCalled();
+
+                // Among the API calls made, one should be to the /oauth endpoint
+                var oauthEndpointCall;
+                YesGraphAPI.hitAPI.calls.all().forEach(function(call) {
+                    if (call.args.indexOf("/oauth") !== 1) {
+                        oauthEndpointCall = call;
+                    }
+                });
+                expect(oauthEndpointCall).toBeDefined();
+                done();
+            });
+        });
+    });
+
     describe("testEmailValidation", function() {
         it("Should identify valid email recipients", function() {
             var inputField = widget.container.find(".yes-manual-input-field");


### PR DESCRIPTION
### What’s this PR do?
- Makes our error handling on the OAuth flow more robust, so that we can properly handle different errors in different browsers.
- Adds tests for the actual OAuth flow! 🎉
- Adds a DOM event ("completed.yesgraph.oauth") when the auth popup finishes, before contacts are imported.

### Any background context you want to provide?
When we open the auth popup, if an error occurs, we want to close the popup and show an error message. However, there are certain whitelisted errors that we should instead catch and ignore. 

We whitelist errors by checking them against a regex pattern, but the pattern was failing to catch some errors in certain browsers, because the error messages vary slightly. This change makes the regex pattern more general, so that we can handle greater variation in the error messages.

Also, whenever an error _doesn't_ get whitelisted, we're now logging it to Sentry. That should help us detect these problems in the future before our customers do.

### Where should the reviewer start?
Start with the new error-catching regex pattern [here](https://github.com/YesGraph/yesgraph-superwidget/compare/error_handling?expand=1#diff-6d2a12d760bbd72a115bede316ba4e18R1138), in src/dev/yesgraph-invites.js.

### Reproducing the error
- In src/demo_widget.html, comment out line 17 and add this instead:
```
<script src="https://cdn.yesgraph.com/v1.1.10/yesgraph-invites.min.js"></script>
```

<img width="775" alt="screen shot 2016-09-30 at 12 57 34 pm" src="https://cloud.githubusercontent.com/assets/10701968/19005042/7e100414-870d-11e6-9444-0dc1906e3b9f.png">

- Run the api server with `make run`, and then the one for this repo with `npm start`
- In Safari, go to [localhost:8080/demo_widget.html](localhost:8080/demo_widget.html) and try to import your contacts. It should fail.

### Testing the solution
Try importing your contacts in Safari, and run `gulp test`.

### What are the relevant tickets?
[Debug atlassian browser compatibility issue](https://app.asana.com/0/59202558034519/189321923173349)
[Trigger a dom event when oauth succeeds/fails](https://app.asana.com/0/59202558034519/188733650266957)
[Add type=button to the contact import buttons](https://app.asana.com/0/59202558034519/187567348463389)