### PR TITLE
Bugfix on promote-matching-domains

### DIFF
--- a/src/dev/yesgraph-invites.js
+++ b/src/dev/yesgraph-invites.js
@@ -1082,7 +1082,8 @@
                     var d = $.Deferred();
                     YesGraphAPI.hitAPI("/oauth", "GET", {
                         "service": self.service.id,
-                        "token_data": JSON.stringify(authData)
+                        "token_data": JSON.stringify(authData),
+                        "settings": YesGraphAPI.settings
                     }).done(function(response){
                         if (response.error) {
                             d.reject(response);


### PR DESCRIPTION
### What’s this PR do?
Passes the `promote-matching-domains` flag from the HTML to the API when ranking contacts

### Any background context you want to provide?

### Where should the reviewer start?

### Does this require changes on the API side?

### How should this be manually tested?

### What are the relevant tickets?

### Screenshots (if appropriate)

### Does the knowledge base need an update?