### PR TITLE
jsonify settings before hitting the api

### DIFF
--- a/src/dev/yesgraph-invites.js
+++ b/src/dev/yesgraph-invites.js
@@ -1082,7 +1082,8 @@
                     var d = $.Deferred();
                     YesGraphAPI.hitAPI("/oauth", "GET", {
                         "service": self.service.id,
-                        "token_data": JSON.stringify(authData)
+                        "token_data": JSON.stringify(authData),
+                        "settings": JSON.stringify(YesGraphAPI.settings)
                     }).done(function(response){
                         if (response.error) {
                             d.reject(response);


### PR DESCRIPTION
### What’s this PR do?
Jsonifies the ranking settings before we hit the /oauth endpoint, so they can be parsed as JSON server side

[WIP]

### Any background context you want to provide?

### Where should the reviewer start?

### Does this require changes on the API side?

### How should this be manually tested?

### What are the relevant tickets?

### Screenshots (if appropriate)

### Does the knowledge base need an update?