### PR TITLE
Only validate settings for apps using our email backend

### DIFF
--- a/src/dev/modules/controller.js
+++ b/src/dev/modules/controller.js
@@ -150,21 +150,21 @@ export default function Controller(model, view) {
                 return;
             }
 
-            // Validate settings
-            var validationResult = self.YesGraphAPI.utils.validateSettings();
-            var hasValidSettings = validationResult[0];
-            if (!hasValidSettings) {
-                var errorMsg = validationResult[1];
-                view.emailSendingFailed({
-                    error: errorMsg
-                });
-                return;
-            }
-
-            // Send the email invites
             $(document).trigger(self.YesGraphAPI.events.SET_RECIPIENTS, [recipients]);
+
+            // Only send the emails if emailSending was not set to `false`
             if (self.YesGraphAPI.settings.emailSending) {
-                model.sendEmailInvites(recipients);
+                // Validate settings
+                var validationResult = self.YesGraphAPI.utils.validateSettings();
+                var hasValidSettings = validationResult[0];
+                if (hasValidSettings) {
+                    model.sendEmailInvites(recipients);
+                } else {
+                    var errorMsg = validationResult[1];
+                    view.emailSendingFailed({
+                        error: errorMsg
+                    });
+                }                
             }
         },
         sawSuggestions: function(suggestedContacts) {


### PR DESCRIPTION
### What’s this PR do?
This PR fixes a bug for customers who aren't using our email backend.

### Any background context you want to provide?
This bug surfaced in the wake of a pretty big refactor. It was caused by an `if`/`else` block that wasn't copied over properly.

We should prevent this going forward by updating our tests to cover more configurations of dashboard settings.

### Where should the reviewer start?
src/dev/modules/controller.js

### Does this require changes on the API side?
No

### How should this be manually tested?
- Create a new app, but _don't_ configure any options for it.
- In the demo_widget.html file, replace the `<span>` & `<script>` tags with this code snippet:
```html
<script class="yesgraph-invites"
    data-app="[YOUR APP ID]" data-contact-importing="false"
    data-email-sending="false" data-invite-link="false" data-share-btns="false"
    data-nolog="true" defer="" id="yesgraph" src="dist/dev/yesgraph-invites.min.js"><div class="yes-widget-container"><div class="yes-header-1"></script>
```
(Be sure to use the id from your newly created app)

- Run this code from your javascript console to load some contacts:
```javascript
YesGraphAPI.Superwidget.modal.loading();
YesGraphAPI.Superwidget.modal.loadContacts([{name: 'Test User', emails:['test@email.com']}]);
YesGraphAPI.Superwidget.modal.openModal();
```
- Send an email, and you shouldn't get any console errors.

### What are the relevant tickets?
[Asana Task: Fix problematic settings validation on the Superwidget](https://app.asana.com/0/205575868494081/222219750761909)

### Does the knowledge base need an update?
No