### PR TITLE
Client key validation

### DIFF
--- a/demo_auth.html
+++ b/demo_auth.html
@@ -11,7 +11,6 @@
 <script>
 YesGraphAPI.setOptions({
     auth: {
-        app: '[YOUR_APP_ID]',
         clientKey: '[YOUR_CLIENT_KEY]'
     },
     settings: {

--- a/src/dev/modules/model.js
+++ b/src/dev/modules/model.js
@@ -44,16 +44,14 @@ export default function Model() {
     };
 
     this.getWidgetOptions = function() {
-        // If the Superwidget already has options set, use those.
-        var existingOptions = self.Superwidget.options;
-        if (existingOptions) {
-            self.notifyGetWidgetOptionsSucceeded(existingOptions);
-            return;
-        }
-
-        // If no options have been set yet, get them from the API
+        // Fetch the options saved on the superwidget dashboard
         var api = self.Superwidget.YesGraphAPI;
-        var OPTIONS_ENDPOINT = '/apps/' + api.app + '/js/get-options';
+        var OPTIONS_ENDPOINT
+        if (api.clientKey) {
+            OPTIONS_ENDPOINT = '/apps/js/get-options';
+        } else {
+            OPTIONS_ENDPOINT = '/apps/' + api.app + '/js/get-options';
+        }
         // Retry failed request up to 3 times, waiting 1500ms between tries
         api.hitAPI(OPTIONS_ENDPOINT, "GET", {}, null, 3, 1500)
             .done(self.notifyGetWidgetOptionsSucceeded)

--- a/src/dev/modules/model.js
+++ b/src/dev/modules/model.js
@@ -46,7 +46,7 @@ export default function Model() {
     this.getWidgetOptions = function() {
         // Fetch the options saved on the superwidget dashboard
         var api = self.Superwidget.YesGraphAPI;
-        var OPTIONS_ENDPOINT
+        var OPTIONS_ENDPOINT;
         if (api.clientKey) {
             OPTIONS_ENDPOINT = '/apps/js/get-options';
         } else {

--- a/src/dev/modules/options.js
+++ b/src/dev/modules/options.js
@@ -21,24 +21,11 @@ export var defaultParsedOptions = {
 };
 
 function parseStructuredOptions(options) {
-    var parsed = $.extend({}, defaultParsedOptions);
-
-    for (let section in defaultParsedOptions) {
-        options[section] = options[section] || {};
-
-        for (let opt in defaultParsedOptions[section]) {
-            if (options[section][opt] === undefined) {
-                parsed[section][opt] = defaultParsedOptions[section][opt];
-            } else {
-                parsed[section][opt] = options[section][opt];
-            }
-        }
-    }
-    return parsed;
+    return $.extend(true, {}, defaultParsedOptions, options);
 }
 
 function parseBasicOptions(options) {
-    var parsed = $.extend({}, defaultParsedOptions);
+    var parsed = $.extend(true, {}, defaultParsedOptions);
     for (let opt in options) {
         let val = options[opt];
         // Sort options in to the right sections
@@ -77,7 +64,7 @@ export function parseOptions(options) {
 export default function waitForOptions(optionsDeferred) {
     // Check the dom periodically until we find an
     // element with the id `yesgraph` to get options from,
-    // or until the .options() method is called.
+    // or until the .setOptions() method is called.
     var d = optionsDeferred || jQuery.Deferred();
     var target;
     var options;

--- a/src/dev/modules/view.js
+++ b/src/dev/modules/view.js
@@ -588,7 +588,7 @@ export default function View() {
     };
 
     this.toggleSelected = function(evt) {
-        var checkbox = $(evt.target).find("[type='checkbox']");
+        var checkbox = $(this).find("input[type='checkbox']");
         checkbox.prop("checked", !checkbox.prop("checked"));
         self.updateModalSendBtn();
     };
@@ -760,9 +760,11 @@ export default function View() {
         });
 
         // "Select All" checkbox
-        $(document).on("click", ".yes-select-all-form [type='checkbox']", function(evt) {
+        $(document).on("click", ".yes-select-all-form *", function(evt) {
+            var is_checked = self.modal.container.find(".yes-select-all").prop("checked");
             var checkboxes = self.modal.container.find(".yes-modal-body [type='checkbox']");
-            checkboxes.prop("checked", $(evt.target).prop("checked"));
+            checkboxes.prop("checked", !is_checked);
+            self.updateModalSendBtn();
         });
 
         // Contact checkboxes

--- a/src/dev/modules/view.js
+++ b/src/dev/modules/view.js
@@ -587,7 +587,7 @@ export default function View() {
         return Boolean(b.name) - Boolean(a.name);
     };
 
-    this.toggleSelected = function(evt) {
+    this.toggleSelected = function() {
         var checkbox = $(this).find("input[type='checkbox']");
         checkbox.prop("checked", !checkbox.prop("checked"));
         self.updateModalSendBtn();
@@ -760,7 +760,7 @@ export default function View() {
         });
 
         // "Select All" checkbox
-        $(document).on("click", ".yes-select-all-form *", function(evt) {
+        $(document).on("click", ".yes-select-all-form *", function() {
             var is_checked = self.modal.container.find(".yes-select-all").prop("checked");
             var checkboxes = self.modal.container.find(".yes-modal-body [type='checkbox']");
             checkboxes.prop("checked", !is_checked);


### PR DESCRIPTION
### What’s this PR do?
- Adds a client key validation step to the Superwidget, so that developers don't need to specify an `app_name` or an `invite_link` when the widget is initialized with a `client_key`.
- It also fixes a bug whereby the text on the "send" button in the contacts modal didn't change if we clicked "select all"
- It also changes the contacts modal UI so that clicking anywhere on the row (not just directly on the checkbox) selects the contact.

### Where should the reviewer start?
Start with the changes in src/dev/modules/api.js

### Does this require changes on the API side?
Yes, see [this PR](https://github.com/YesGraph/api.yesgraph.com/pull/766).

### How should this be manually tested?
Run `npm test`.

It can also be tested by loading the widget with a client key:
1. Create a client key. More on that [here](#).
2. Update demo_auth.html to include your client key
3. Run `npm start` to boot up the server, then load the widget on [localhost:8080/demo_auth.html](http://localhost:8080/demo_auth.html)

*This depends on the changes from [this PR](https://github.com/YesGraph/api.yesgraph.com/pull/766), so run the API server from the `js_options` branch.*

### What are the relevant tickets?
[Asana Task: Enhance JS SDK to support retrieving Address Books via Client Key](https://app.asana.com/0/205575868494081/222959186660224)

### Does the knowledge base need an update?
Yes. We have [a task](https://app.asana.com/0/205575868494081/224121500534075) for that.