### PR TITLE
added data param to select option set

### DIFF
--- a/demo_widget.html
+++ b/demo_widget.html
@@ -8,7 +8,7 @@
 <script src="dist/dev/yesgraph-invites.min.js"></script>
 <span id="yesgraph" class="yesgraph-invites"
       data-app="2b8520aa-ff19-4607-a829-46f928318fde" data-email="some@email.com"
-      data-name="Some Name" data-foo="bar" data-user-editable=true>
+      data-name="Some Name" data-foo="bar" data-options-id='staff'>
 </span>
 
 </body>

--- a/demo_widget.html
+++ b/demo_widget.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title></title>
+    <title>YesGraph</title>
 </head>
 <body>
 
 <script src="dist/dev/yesgraph-invites.min.js"></script>
 <span id="yesgraph" class="yesgraph-invites"
-      data-app="YesGraph" data-email="some@email.com"
-      data-name="Some Name" data-foo="bar">
+      data-app="2b8520aa-ff19-4607-a829-46f928318fde" data-email="some@email.com"
+      data-name="Some Name" data-foo="bar" data-user-editable=true>
 </span>
 
 </body>

--- a/src/dev/modules/model.js
+++ b/src/dev/modules/model.js
@@ -46,7 +46,7 @@ export default function Model() {
     this.getWidgetOptions = function() {
         // Fetch the options saved on the superwidget dashboard
         var api = self.Superwidget.YesGraphAPI;
-        var options_id = api.settings.optionsId;
+        var userEditable = api.settings.userEditable;
         var OPTIONS_ENDPOINT;
         if (api.clientKey) {
             OPTIONS_ENDPOINT = '/apps/js/get-options';
@@ -54,7 +54,7 @@ export default function Model() {
             OPTIONS_ENDPOINT = '/apps/' + api.app + '/js/get-options';
         }
         // Retry failed request up to 3 times, waiting 1500ms between tries
-        api.hitAPI(OPTIONS_ENDPOINT, "GET", {"options_id": options_id}, null, 3, 1500)
+        api.hitAPI(OPTIONS_ENDPOINT, "GET", {"userEditable": userEditable}, null, 3, 1500)
             .done(self.notifyGetWidgetOptionsSucceeded)
             .fail(self.notifyGetWidgetOptionsFailed);
     };

--- a/src/dev/modules/model.js
+++ b/src/dev/modules/model.js
@@ -46,7 +46,7 @@ export default function Model() {
     this.getWidgetOptions = function() {
         // Fetch the options saved on the superwidget dashboard
         var api = self.Superwidget.YesGraphAPI;
-        var userEditable = api.settings.userEditable;
+        var userEditable = Boolean(api.settings.optionsId != 'staff');
         var OPTIONS_ENDPOINT;
         if (api.clientKey) {
             OPTIONS_ENDPOINT = '/apps/js/get-options';
@@ -64,8 +64,8 @@ export default function Model() {
         api.hitAPI("/send-email-invites", "POST", {
             recipients: recipients,
             test: TESTMODE || undefined,
-            invite_link: api.inviteLink
-
+            invite_link: api.inviteLink,
+            userEditable: api.settings.userEditable
         }).done(function (resp) {
             if (!resp.emails) {
                 self.notifyEmailSendingFailed(resp);

--- a/src/dev/modules/model.js
+++ b/src/dev/modules/model.js
@@ -1,4 +1,5 @@
 import { SUPERWIDGET_VERSION, CSS_VERSION } from "./consts.js";
+
 export default function Model() {
     // Basic infraestructure
     var self = this;
@@ -52,7 +53,6 @@ export default function Model() {
         } else {
             OPTIONS_ENDPOINT = '/apps/' + api.app + '/js/get-options';
         }
-
         // Retry failed request up to 3 times, waiting 1500ms between tries
         api.hitAPI(OPTIONS_ENDPOINT, "GET", {"options_id": options_id}, null, 3, 1500)
             .done(self.notifyGetWidgetOptionsSucceeded)

--- a/src/dev/modules/model.js
+++ b/src/dev/modules/model.js
@@ -1,5 +1,4 @@
 import { SUPERWIDGET_VERSION, CSS_VERSION } from "./consts.js";
-
 export default function Model() {
     // Basic infraestructure
     var self = this;
@@ -46,14 +45,16 @@ export default function Model() {
     this.getWidgetOptions = function() {
         // Fetch the options saved on the superwidget dashboard
         var api = self.Superwidget.YesGraphAPI;
+        var options_id = api.settings.optionsId;
         var OPTIONS_ENDPOINT;
         if (api.clientKey) {
             OPTIONS_ENDPOINT = '/apps/js/get-options';
         } else {
             OPTIONS_ENDPOINT = '/apps/' + api.app + '/js/get-options';
         }
+
         // Retry failed request up to 3 times, waiting 1500ms between tries
-        api.hitAPI(OPTIONS_ENDPOINT, "GET", {}, null, 3, 1500)
+        api.hitAPI(OPTIONS_ENDPOINT, "GET", {"options_id": options_id}, null, 3, 1500)
             .done(self.notifyGetWidgetOptionsSucceeded)
             .fail(self.notifyGetWidgetOptionsFailed);
     };

--- a/src/dev/modules/options.js
+++ b/src/dev/modules/options.js
@@ -12,6 +12,7 @@ export var defaultParsedOptions = {
         emailSending: true,
         inviteLink: true,
         shareBtns: true,
+        optionsId: "0",
         nolog: false
     },
     user: {},

--- a/src/dev/modules/options.js
+++ b/src/dev/modules/options.js
@@ -17,7 +17,7 @@ export var defaultParsedOptions = {
         emailSending: true,
         inviteLink: true,
         shareBtns: true,
-        optionsId: "0",
+        userEditable: true,
         nolog: false
     },
     user: {},

--- a/src/dev/modules/options.js
+++ b/src/dev/modules/options.js
@@ -17,7 +17,7 @@ export var defaultParsedOptions = {
         emailSending: true,
         inviteLink: true,
         shareBtns: true,
-        userEditable: true,
+        optionsId: 'default',
         nolog: false
     },
     user: {},

--- a/src/dev/modules/options.js
+++ b/src/dev/modules/options.js
@@ -1,3 +1,8 @@
+/*
+Reads data attributes from the HTML widget span. 
+*/
+
+// Default options to be overwritten by data-attributes on the HTML widget span.
 export var defaultParsedOptions = {
     auth: {
         app: null,
@@ -21,51 +26,12 @@ export var defaultParsedOptions = {
     }
 };
 
-function parseStructuredOptions(options) {
-    return $.extend(true, {}, defaultParsedOptions, options);
-}
-
-function parseBasicOptions(options) {
-    var parsed = $.extend(true, {}, defaultParsedOptions);
-    for (let opt in options) {
-        let val = options[opt];
-        // Sort options in to the right sections
-        if (parsed.auth.hasOwnProperty(opt)) {
-            parsed.auth[opt] = val;
-        } else if (parsed.settings.hasOwnProperty(opt)) {
-            parsed.settings[opt] = val;
-        } else {
-            parsed.user[opt] = val;
-        }
-        // Detect whether the developer used `CURRENT_USER_*` in their HTML
-        if (typeof val === "string" && val.slice(0,12) == "CURRENT_USER") {
-            parsed.warnings.loadedDefaultParams = true;
-        }
-    }
-    return parsed;
-}
-
-function optionsAreStructured(options) {
-    for (let key in options) {
-        if (defaultParsedOptions[key] === undefined) return false;
-    }
-    return true;
-}
-
-export function parseOptions(options) {
-    var parsed;
-    if (optionsAreStructured(options)) {
-        parsed = parseStructuredOptions(options);
-    } else {
-        parsed = parseBasicOptions(options);
-    }
-    return parsed;
-}
-
 export default function waitForOptions(optionsDeferred) {
-    // Check the dom periodically until we find an
-    // element with the id `yesgraph` to get options from,
-    // or until the .setOptions() method is called.
+    /* 
+    Check the dom periodically until we find an
+    element with the id `yesgraph` to get options from,
+    or until the .setOptions() method is called.
+    */
     var d = optionsDeferred || jQuery.Deferred();
     var target;
     var options;
@@ -78,4 +44,47 @@ export default function waitForOptions(optionsDeferred) {
     }, 100);
     d.always(function(){ clearInterval(timer); });
     return d.promise();
+}
+
+export function parseOptions(options) {
+    /*
+    Merges the default widget options and the options retrieved from the server's api/views/superwidget endpoint.
+    */
+    var parsed;
+    
+    // If the user has not added any attributes to the widget, simply take those options
+    if (optionsAreStructured(options)) {
+        parsed = $.extend(true, {}, defaultParsedOptions, options);
+    } 
+    
+    // If the user has added their own attributes, parse them and add them to the dictionary.
+    else {
+        parsed = $.extend(true, {}, defaultParsedOptions);
+        for (let opt in options) {
+            let val = options[opt];
+            // Sort options in to the right sections
+            if (parsed.auth.hasOwnProperty(opt)) {
+                parsed.auth[opt] = val;
+            } else if (parsed.settings.hasOwnProperty(opt)) {
+                parsed.settings[opt] = val;
+            } else {
+                parsed.user[opt] = val;
+            }
+            // Detect whether the developer used `CURRENT_USER_*` in their HTML
+            if (typeof val === "string" && val.slice(0,12) == "CURRENT_USER") {
+                parsed.warnings.loadedDefaultParams = true;
+            }
+        }    
+    }
+    return parsed;
+}
+
+function optionsAreStructured(options) {
+    /* 
+    Checks if the user has added any attributes to the widget.
+    */
+    for (let key in options) {
+        if (defaultParsedOptions[key] === undefined) return false;
+    }
+    return true;
 }


### PR DESCRIPTION
#### What’s this PR do?
Fixes a bug on the Address Book page where we would sometimes use bad superwidget options, and sets the stage for us to allow our users to have multiple superwidget options to select from.

#### How should this be manually tested?
Create a new project locally, then get it's app name and replace it everywhere this pr has [APPNAME]. 

Run this on your local db to get the superwidget options, options_id=0 has no share options, options_id=1 has share options. 

`INSERT INTO "superwidget_options"("id","app_name","saved_at","share_btns","tweet_msg","fb_app_id","url_to_share","gg_client_id","gg_redirect_url","email_invite_html","email_invite_subject","sg_api_key","contacts_modal_header","manual_input_send_button","widget_headline","default_sender_email","contact_import_btn_cta","email_service_provider","iterable_api_key","iterable_campaign_id","default_gg_credentials","sendwithus_api_key","sendwithus_template_id","default_sender_name","email_invite_text","mailgun_api_key","mailgun_email_domain","template_vars","mailchimp_api_key","mailchimp_list_id","mailchimp_data_center","default_outlook_credentials","outlook_client_secret","outlook_client_id","outlook_redirect_url","linkback","default_yahoo_credentials","yahoo_client_id","yahoo_client_secret","yahoo_redirect_url","modal_send_button_none","modal_send_button_one","modal_send_button_many","manual_input_placeholder","gg_client_secret","default_slack_credentials","slack_client_id","slack_client_secret","slack_redirect_url","options_id")
VALUES
(471,E'[APPNAME]',E'2016-12-07 22:42:01.325566',E'{}',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,TRUE,NULL,NULL,NULL,NULL,NULL,NULL,E'{email,fname,lname}',NULL,NULL,NULL,TRUE,NULL,NULL,NULL,FALSE,TRUE,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,TRUE,NULL,NULL,NULL,0),
(472,E'[APPNAME]',E'2016-12-07 22:42:01.327728',E'{twitter,facebook,linkedin}',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,TRUE,NULL,NULL,NULL,NULL,NULL,NULL,E'{email,fname,lname}',NULL,NULL,NULL,TRUE,NULL,NULL,NULL,FALSE,TRUE,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,TRUE,NULL,NULL,NULL,1);`

And put this in your demo_widget.html
<title>YesGraph</title>
<span id="yesgraph" class="yesgraph-invites"
      data-app="[APPNAME]" data-email="some@email.com"
      data-name="Some Name" data-foo="bar" data-options-id=1>
</span>

And pull the new yesgraph api code, and run that locally.

Then run `npm start` and load the demo widget page. If you change the`data-user-editable` parameter from true to false and restart your server you will see the share buttons or not depending on that setting, verifying that you are selecting different options. 