### PR TITLE
Suggested seen

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -36,7 +36,19 @@ module.exports = {
             files: src.root + "/**/yesgraph-invites.less"
         },
         consts: {
-            files: dest.root + "/**/yesgraph?(-invites)?(.min).js"
+            files: dest.root + "/**/yesgraph?(-invites)?(.min).js",
+            values: {
+                prod: {
+                    YESGRAPH_BASE_URL: "https://api.yesgraph.com",
+                    PUBLIC_RAVEN_DSN: "https://2f5e2b0beb494197b745f10f9fca6c9d@app.getsentry.com/79844",
+                    RUNNING_LOCALLY: false
+                },
+                dev: {
+                    YESGRAPH_BASE_URL: "http://localhost:5001",
+                    PUBLIC_RAVEN_DSN: "https://26657ee86c48458ea5c65e27de766715@app.getsentry.com/81078",
+                    RUNNING_LOCALLY: true
+                }
+            }
         },
         lint: {
             files: src.dev + "/**/*.js",

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -35,6 +35,9 @@ module.exports = {
         compileLess: {
             files: src.root + "/**/yesgraph-invites.less"
         },
+        consts: {
+            files: dest.root + "/**/yesgraph?(-invites)?(.min).js"
+        },
         lint: {
             files: src.dev + "/**/*.js",
             reportFile: root + "/jshint-report.txt",

--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -3,5 +3,5 @@ var gulp = require("gulp");
 var sequence = require("run-sequence").use(gulp);
 
 gulp.task("build", ["clean"], function(done){
-    sequence("compile:less", "bundle", "version", "minify", done);
+    sequence("compile:less", "bundle", "consts", "version", "minify", done);
 });

--- a/gulp/tasks/consts.js
+++ b/gulp/tasks/consts.js
@@ -1,0 +1,38 @@
+var gulp = require("gulp");
+var gutil = require("gulp-util");
+var argv = require("yargs").argv;
+var config = require("../config");
+var replace = require("gulp-replace");
+var debug = require("gulp-debug");
+
+var PROD_OR_DEV;
+var consts = {
+    prod: {
+        YESGRAPH_BASE_URL: "https://api.yesgraph.com",
+        PUBLIC_RAVEN_DSN: "https://2f5e2b0beb494197b745f10f9fca6c9d@app.getsentry.com/79844",
+        RUNNING_LOCALLY: false
+    },
+    dev: {
+        YESGRAPH_BASE_URL: "http://localhost:5001",
+        PUBLIC_RAVEN_DSN: "https://26657ee86c48458ea5c65e27de766715@app.getsentry.com/81078",
+        RUNNING_LOCALLY: true
+    }
+}
+
+gulp.task("consts", function() {
+    PROD_OR_DEV = isLocalBuild() ? "dev" : "prod";
+    return gulp.src(config.tasks.consts.files, {base: config.src.root})
+        .pipe(debug({ title: "consts" }))
+        .pipe(replace(/__CONST_(\w*)__/g, constReplacer))
+        .pipe(gulp.dest(config.dest.root));
+
+});
+
+function isLocalBuild() {
+    return argv.local !== "false";
+}
+
+function constReplacer(match, target) {
+    var result = consts[PROD_OR_DEV][target.toUpperCase()];
+    return result;
+}

--- a/gulp/tasks/consts.js
+++ b/gulp/tasks/consts.js
@@ -1,3 +1,4 @@
+"use strict";
 var gulp = require("gulp");
 var gutil = require("gulp-util");
 var argv = require("yargs").argv;
@@ -6,6 +7,20 @@ var debug = require("gulp-debug");
 var config = require("../config");
 var consts = config.tasks.consts.values;
 var PROD_OR_DEV;
+
+/*
+ * This task replaces certain constants in the source code that should be
+ * determined by the build environment.
+ *
+ * Options:
+ * --local=false
+ *
+ * Example: Build the Superwidget such that it will use localhost for the API url:
+ * `$ gulp build`
+ *
+ * Example: Build the Superwidget such that it will use api.yesgraph.com for the API url:
+ * `$ gulp build --local=false`
+ */
 
 gulp.task("consts", function() {
     PROD_OR_DEV = isLocalBuild() ? "dev" : "prod";

--- a/gulp/tasks/consts.js
+++ b/gulp/tasks/consts.js
@@ -1,23 +1,11 @@
 var gulp = require("gulp");
 var gutil = require("gulp-util");
 var argv = require("yargs").argv;
-var config = require("../config");
 var replace = require("gulp-replace");
 var debug = require("gulp-debug");
-
+var config = require("../config");
+var consts = config.tasks.consts.values;
 var PROD_OR_DEV;
-var consts = {
-    prod: {
-        YESGRAPH_BASE_URL: "https://api.yesgraph.com",
-        PUBLIC_RAVEN_DSN: "https://2f5e2b0beb494197b745f10f9fca6c9d@app.getsentry.com/79844",
-        RUNNING_LOCALLY: false
-    },
-    dev: {
-        YESGRAPH_BASE_URL: "http://localhost:5001",
-        PUBLIC_RAVEN_DSN: "https://26657ee86c48458ea5c65e27de766715@app.getsentry.com/81078",
-        RUNNING_LOCALLY: true
-    }
-}
 
 gulp.task("consts", function() {
     PROD_OR_DEV = isLocalBuild() ? "dev" : "prod";

--- a/gulp/tasks/version.js
+++ b/gulp/tasks/version.js
@@ -25,7 +25,7 @@ var versions = config.version;
  * `$ gulp version --update:minor superwidget --update:patch css`
  */
 
-gulp.task("version", function() {
+gulp.task("version", ["consts"], function() {
     setUpdateType();
     var stream_;
     var streams = merge();

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -5,7 +5,7 @@ var config = require("../config");
 var sequence = require("run-sequence").use(gulp);
 
 gulp.task("_js", function(done) {
-    return sequence("bundle", "version", "minify", done);
+    return sequence("bundle", "consts", "version", "minify", done);
 });
 
 gulp.task("watch", function(){

--- a/package.json
+++ b/package.json
@@ -66,12 +66,15 @@
     "presets": ["es2015"]
   },
   "scripts": {
-    "test": "node_modules/karma/bin/karma start karma.conf.js --single-run; gulp lint;",
-    "test:debug": "gulp lint; node_modules/karma/bin/karma start karma.conf.js;",
+    "test": "gulp build --local=false; node_modules/karma/bin/karma start karma.conf.js --single-run; gulp lint;",
+    "test:local": "gulp build gulp lint; node_modules/karma/bin/karma start karma.conf.js;",
+    "test:debug": "gulp build --local=false; gulp lint; node_modules/karma/bin/karma start karma.conf.js;",
     "build": "gulp build",
+    "build:prod": "gulp build --local=false",
     "lint": "gulp lint",
     "clean": "gulp clean",
-    "start": "gulp build; echo \"Starting server at localhost:8080\"; python3 -m http.server 8080;"
+    "start": "gulp build; echo \"Starting server at localhost:8080\"; python3 -m http.server 8080;",
+    "start:prod": "gulp build --local=false; echo \"Starting server at localhost:8080\"; python3 -m http.server 8080;"
   },
   "repository": {
     "type": "git",

--- a/src/dev/modules/api.js
+++ b/src/dev/modules/api.js
@@ -275,6 +275,7 @@ export default function YesGraphAPIConstructor() {
         storeClientKey: function (data) {
             self.inviteLink = data.inviteLink;
             self.app = data.app_name;
+            self.user.user_id = data.user_id;
         },
         validateClientKey: function (userData) {
             var data = { userData: userData };

--- a/src/dev/modules/api.js
+++ b/src/dev/modules/api.js
@@ -96,6 +96,10 @@ export default function YesGraphAPIConstructor() {
     };
 
     this.postSuggestedSeen = function (seenContacts, done, maxTries, interval) {
+        // Ensure that a `user_id` is included whenever clientKey auth is used
+        if (self.clientKey != undefined && seenContacts.entries) {  // jshint ignore:line
+            seenContacts.entries.forEach(entry => entry.user_id = entry.user_id || self.user.user_id);
+        }
         return self.hitAPI("/suggested-seen", "POST", seenContacts, done, maxTries, interval);
     };
 

--- a/src/dev/modules/consts.js
+++ b/src/dev/modules/consts.js
@@ -14,30 +14,13 @@ var EVENTS = {
     INVITES_SENT: "Invite(s) Sent",
     CLIPBOARD_FAILED: "Clipboard Failed to Load"
 };
-var YESGRAPH_BASE_URL;
-var YESGRAPH_API_URL;
-var PUBLIC_RAVEN_DSN;
-var RUNNING_LOCALLY;
-
-// Initialize in dev-mode as appropriate
-if (["localhost", "lvh.me"].indexOf(window.location.hostname) !== -1 && window.document.title === 'YesGraph') {
-    YESGRAPH_BASE_URL = "http://localhost:5001";
-    PUBLIC_RAVEN_DSN = "https://26657ee86c48458ea5c65e27de766715@app.getsentry.com/81078";
-    RUNNING_LOCALLY = true;
-} else {
-    YESGRAPH_BASE_URL = "https://api.yesgraph.com";
-    PUBLIC_RAVEN_DSN = "https://2f5e2b0beb494197b745f10f9fca6c9d@app.getsentry.com/79844";
-    RUNNING_LOCALLY = false;
-}
-YESGRAPH_API_URL = YESGRAPH_BASE_URL + '/v0';
+var YESGRAPH_BASE_URL = "__CONST_YESGRAPH_BASE_URL__";
+var YESGRAPH_API_URL = YESGRAPH_BASE_URL + '/v0';
+var PUBLIC_RAVEN_DSN = "__CONST_PUBLIC_RAVEN_DSN__";
+var RUNNING_LOCALLY = "__CONST_RUNNING_LOCALLY__" === "true" ? true : false;
 
 // Check the protocol used by the window
-var PROTOCOL;
-if (window.location.protocol.indexOf("http") !== -1) {
-    PROTOCOL = window.location.protocol;
-} else {
-    PROTOCOL = "http:";
-}
+var PROTOCOL = window.location.protocol.startsWith("http") ? window.location.protocol : "http:";
 
 export {
     SUPERWIDGET_VERSION,

--- a/src/dev/modules/model.js
+++ b/src/dev/modules/model.js
@@ -87,9 +87,6 @@ export default function Model() {
     };
 
     this.sawSuggestions = function(suggestedContacts) {
-        suggestedContacts.forEach(entry => {
-            entry.user_id = self.Superwidget.YesGraphAPI.user.user_id;
-        });
         self.Superwidget.YesGraphAPI.postSuggestedSeen({ entries: suggestedContacts });
     };
 

--- a/src/dev/modules/model.js
+++ b/src/dev/modules/model.js
@@ -87,6 +87,9 @@ export default function Model() {
     };
 
     this.sawSuggestions = function(suggestedContacts) {
+        suggestedContacts.forEach(entry => {
+            entry.user_id = self.Superwidget.YesGraphAPI.user.user_id;
+        });
         self.Superwidget.YesGraphAPI.postSuggestedSeen({ entries: suggestedContacts });
     };
 

--- a/tests/test_api.js
+++ b/tests/test_api.js
@@ -29,6 +29,37 @@ describe('testAPI', function() {
         expect(window.YesGraphAPI).toBeDefined();
     });
 
+    describe("testClientKey", function() {
+        beforeAll(() => {
+            YesGraphAPI.clientKey = "some-client-key";
+            YesGraphAPI.user.user_id = "some-user-id";
+        });
+        afterAll(() => {
+            YesGraphAPI.clientKey = undefined;
+            YesGraphAPI.user.user_id = "some-user-id";
+        });
+
+        it('Should add a `user_id` when hittings /suggested-seen with a clientKey', (done) => {
+            expect(YesGraphAPI).toBeDefined();
+            var spy = spyOn(YesGraphAPI, "hitAPI").and.callFake((endpoint, _, data) => {
+                // Check that user_ids were added to the entries
+                if (endpoint === "/suggested-seen") {
+                    data.entries.forEach(entry => expect(entry.user_id).toBeDefined());
+                    done();
+                }
+            });
+
+            // POST some entries without user_ids
+            var entries = [
+                { "emails": ["test1@email.com"] },
+                { "emails": ["test2@email.com"] },
+                { "emails": ["test3@email.com"] },
+            ];
+            YesGraphAPI.postSuggestedSeen({ entries: entries })
+        });
+
+    });
+
     describe("testInstall", function() {
         it('Should load YesGraphAPI.Raven', function() {
             // After Raven loads automatically, remove it and

--- a/tests/test_api.js
+++ b/tests/test_api.js
@@ -30,21 +30,23 @@ describe('testAPI', function() {
     });
 
     describe("testClientKey", function() {
-        beforeAll(() => {
+        beforeAll(function() {
             YesGraphAPI.clientKey = "some-client-key";
             YesGraphAPI.user.user_id = "some-user-id";
         });
-        afterAll(() => {
+        afterAll(function() {
             YesGraphAPI.clientKey = undefined;
             YesGraphAPI.user.user_id = "some-user-id";
         });
 
-        it('Should add a `user_id` when hittings /suggested-seen with a clientKey', (done) => {
+        it('Should add a `user_id` when hittings /suggested-seen with a clientKey', function(done) {
             expect(YesGraphAPI).toBeDefined();
-            var spy = spyOn(YesGraphAPI, "hitAPI").and.callFake((endpoint, _, data) => {
+            var spy = spyOn(YesGraphAPI, "hitAPI").and.callFake(function(endpoint, _, data) {
                 // Check that user_ids were added to the entries
                 if (endpoint === "/suggested-seen") {
-                    data.entries.forEach(entry => expect(entry.user_id).toBeDefined());
+                    data.entries.forEach(function(entry) {
+                        expect(entry.user_id).toBeDefined()
+                    });
                     done();
                 }
             });


### PR DESCRIPTION
### What’s this PR do?
- Changes the way we detect a local dev environment
    - Previously we had a hacky way of checking the URL and the title of the page. Now we're defining it in the build process instead.
- Includes the `user_id` when we hit the /suggested-seen endpoint with a clientKey
    - The `user_id` is optional with a ClientToken, but required with a ClientKey.

### Where should the reviewer start?
It's easiest to understand what's going on by trying it, so I'd suggest doing the tests first and then looking at package.json & gulp/tasks/consts.js

### Does this require changes on the API side?
Nope

### How should this be manually tested?
**Testing /suggested-seen:**
I've added an automated test for this, so you can just run `npm test`

**Testing Build Changes**
1. Run `npm start`.
2. From the "Network" tab in the console, you should see that the Superwidget is accessing the local version of the API:
![dev](https://cloud.githubusercontent.com/assets/10701968/21023055/c51bd0b6-bd33-11e6-9efe-a53beaffe315.png)

3. Then kill the server and instead run `npm run start:prod`.
4. From the "Network" tab in the console, you should see that the Superwidget is now accessing api.yesgraph.com instead of localhost:
Starting the server with `npm run start:prod` yeilds this result:
![prod](https://cloud.githubusercontent.com/assets/10701968/21023013/95127aaa-bd33-11e6-9ee1-2cae87debbb1.png)

### What are the relevant tickets?
[Asana Task: Change how the widget detects a local dev environment](https://app.asana.com/0/59202558034519/215631670625173)
[Asana Task: Debug failing /suggested-seen requests](https://app.asana.com/0/59202558034519/227639858328946)

### Does the knowledge base need an update?
I'll add a note to the wiki about the build changes.