### PR TITLE
Auth headers

### DIFF
--- a/demo_widget.html
+++ b/demo_widget.html
@@ -7,8 +7,7 @@
 
 <script src="dist/dev/yesgraph-invites.min.js"></script>
 <span id="yesgraph" class="yesgraph-invites"
-      data-app="YesGraph" data-email="some@email.com"
-      data-name="Some Name" data-foo="bar" data-options-id='staff'>
+      data-app="19185f1f-a583-4c6b-bc5f-8aff04dc1020">
 </span>
 
 </body>

--- a/src/dev/modules/api.js
+++ b/src/dev/modules/api.js
@@ -24,17 +24,17 @@ export default function YesGraphAPIConstructor() {
         } else if (method.toUpperCase() !== "GET") {
             data = JSON.stringify(data || {});
         }
-
-        var auth = self.clientKey ? "Bearer " + self.clientKey : "ClientToken " + self.clientToken;
         var ajaxSettings = {
             url: YESGRAPH_API_URL + endpoint,
             data: data,
-            contentType: "application/json; charset=UTF-8",
-            headers: {
-                "Authorization": auth
-            }
+            contentType: "application/json; charset=UTF-8"
         };
-
+        // Add authorization headers if we have a ClientKey or ClientToken
+        if (self.clientKey) {
+            ajaxSettings.headers = { Authorization: "Bearer " + self.clientKey };
+        } else if (self.clientToken) {
+            ajaxSettings.headers = { Authorization: "ClientToken " + self.clientToken };
+        }
         // In jQuery 1.9+, the jQuery.ajax "type" is changed to "method"
         if (jQuery.fn.jquery < "1.9") {
             ajaxSettings.type = method;

--- a/src/dev/modules/consts.js
+++ b/src/dev/modules/consts.js
@@ -20,7 +20,7 @@ var PUBLIC_RAVEN_DSN = "__CONST_PUBLIC_RAVEN_DSN__";
 var RUNNING_LOCALLY = "__CONST_RUNNING_LOCALLY__" === "true" ? true : false;
 
 // Check the protocol used by the window
-var PROTOCOL = window.location.protocol.startsWith("http") ? window.location.protocol : "http:";
+var PROTOCOL = (window.location.protocol.slice(0,4) == "http") ? window.location.protocol : "http:";
 
 export {
     SUPERWIDGET_VERSION,

--- a/src/dev/modules/view.js
+++ b/src/dev/modules/view.js
@@ -592,8 +592,8 @@ export default function View() {
         if (!target.is("input[type='checkbox']")) {
             var checkbox = $(this).find("input[type='checkbox']");
             checkbox.prop("checked", !checkbox.prop("checked"));
-            self.updateModalSendBtn();            
         }
+        self.updateModalSendBtn();            
     };
 
     this.applyStyling = function() {
@@ -763,10 +763,10 @@ export default function View() {
         });
 
         // "Select All" checkbox
-        $(document).on("click", ".yes-select-all-form *", function() {
-            var is_checked = self.modal.container.find(".yes-select-all").prop("checked");
+        $(document).on("click", ".yes-select-all", function() {
+            var selectAll = $(this);
             var checkboxes = self.modal.container.find(".yes-modal-body [type='checkbox']");
-            checkboxes.prop("checked", !is_checked);
+            checkboxes.prop("checked", selectAll.prop("checked"));
             self.updateModalSendBtn();
         });
 

--- a/tests/fixtures.html
+++ b/tests/fixtures.html
@@ -1,3 +1,3 @@
 
-<div id="yesgraph" class="yesgraph-invites" data-testmode=true data-app="19185f1f-a583-4c6b-bc5f-8aff04dc1020" data-foo="bar"></div>
+<div id="yesgraph" class="yesgraph-invites" data-testmode=true data-app="19185f1f-a583-4c6b-bc5f-8aff04dc1020" data-referral_code="1234"></div>
 

--- a/tests/test_api.js
+++ b/tests/test_api.js
@@ -130,6 +130,7 @@ describe('testAPI', function() {
         it('Should use a clientKey if available', function(done) {
             var ajaxSpy = spyOn($, "ajax").and.callFake(function(settings) {
                 expect(settings.headers.Authorization).toEqual("Bearer " + YesGraphAPI.clientKey);
+                YesGraphAPI.clientKey = undefined;
                 done();
             });
             YesGraphAPI.clientKey = "TEST_CLIENT_KEY";


### PR DESCRIPTION
### What’s this PR do?
Omits the "Authorization" header from requests where we don't have an auth key yet (i.e., when we're getting a client token for the first time).

Previously, if there was no client token available, we were sending this header: `Authorization ClientToken undefined`.

On the API side when we check for authorization headers, it's ok if the ClientToken is omitted, but we reject invalid client tokens. So `undefined` gets parsed as an invalid client token and the request is rejected :(

### Any background context you want to provide?
This came up because we added a decorator to one of our `api.before_request` functions. The decorator started checking this `undefined` client token and rejecting request before we have a chance to generate a valid one in the view.

The related API code is in [this PR](https://github.com/YesGraph/api.yesgraph.com/pull/784). See [this comment](https://github.com/YesGraph/api.yesgraph.com/pull/784/files#diff-a457ac0d1f149f9ee24cd2548cc9358aR39) in particular.

### Where should the reviewer start?
Review the changes to the `hitAPI` method in src/dev/modules/api.js
 
### Does this require changes on the API side?
We rolled-back the code causing the bug, but once this is merged we can deploy it again.

### How should this be manually tested?
To reproduce the error:
1. Run the API server & make sure you have the most recent changes from the master branch
2. Run `npm start` & go to [localhost:8080/demo_widget.html](http://localhost:8080/demo_widget.html) from an Incognito window
You should see console errors, like in the screenshot below.
3. Pull the changes from this branch & repeat.
The console errors should be gone and the widget should appear.

### What are the relevant tickets?
[Asana Task: Omit superwidget auth headers if auth key/token is missing](https://app.asana.com/0/59202558034519/231896473272741)
[Sentry Error: Invalid client token: undefined](https://sentry.io/yesgraph/superwidget/issues/152881897/)
[API PR #784](https://github.com/YesGraph/api.yesgraph.com/pull/784) (see [this comment](https://github.com/YesGraph/api.yesgraph.com/pull/784/files#diff-a457ac0d1f149f9ee24cd2548cc9358aR39))

### Screenshots (if appropriate)
![screen shot 2016-12-15 at 12 34 09 pm](https://cloud.githubusercontent.com/assets/10701968/21242204/118268d6-c2c8-11e6-8524-4058fcfcb50c.png)

### Does the knowledge base need an update?
Nope