### PR TITLE
Send-email-invites fix

### DIFF
--- a/demo_widget.html
+++ b/demo_widget.html
@@ -6,9 +6,6 @@
 <body>
 
 <script src="dist/dev/yesgraph-invites.min.js"></script>
-<!--span id="yesgraph" class="yesgraph-invites"
-      data-app="ebb8181c-26c7-4fcf-abaa-24dbd8b7a1b1" data-invite="sJfplHawSIUuDezE3D9ktn" data-options-id="staff">
-</span-->
-<span id="yesgraph" class="yesgraph-invites" data-app="ebb8181c-26c7-4fcf-abaa-24dbd8b7a1b1" data-email="martin@yesgraph.com" data-name="Martin Clyde Sheldon Weiss" data-invite="sJfplHawSIUuDezE3D9ktn" data-promote-matching-domain="1"></span>
+<span id="yesgraph" class="yesgraph-invites" data-app="ebb8181c-26c7-4fcf-abaa-24dbd8b7a1b1"></span>
 </body>
 </html>

--- a/demo_widget.html
+++ b/demo_widget.html
@@ -6,9 +6,9 @@
 <body>
 
 <script src="dist/dev/yesgraph-invites.min.js"></script>
-<span id="yesgraph" class="yesgraph-invites"
-      data-app="19185f1f-a583-4c6b-bc5f-8aff04dc1020">
-</span>
-
+<!--span id="yesgraph" class="yesgraph-invites"
+      data-app="ebb8181c-26c7-4fcf-abaa-24dbd8b7a1b1" data-invite="sJfplHawSIUuDezE3D9ktn" data-options-id="staff">
+</span-->
+<span id="yesgraph" class="yesgraph-invites" data-app="ebb8181c-26c7-4fcf-abaa-24dbd8b7a1b1" data-email="martin@yesgraph.com" data-name="Martin Clyde Sheldon Weiss" data-invite="sJfplHawSIUuDezE3D9ktn" data-promote-matching-domain="1"></span>
 </body>
 </html>

--- a/src/dev/modules/model.js
+++ b/src/dev/modules/model.js
@@ -61,11 +61,12 @@ export default function Model() {
 
     this.sendEmailInvites = function(recipients) {
         var api = self.Superwidget.YesGraphAPI;
+        var userEditable = Boolean(api.settings.optionsId != 'staff');
         api.hitAPI("/send-email-invites", "POST", {
             recipients: recipients,
             test: TESTMODE || undefined,
             invite_link: api.inviteLink,
-            userEditable: api.settings.userEditable
+            userEditable: userEditable,
         }).done(function (resp) {
             if (!resp.emails) {
                 self.notifyEmailSendingFailed(resp);


### PR DESCRIPTION
### What does this PR do:
Fixes the email sending functionality of the widget.

### How to manually test it
First we will reproduce the error, then we will fix it.
pull the master version of the superwidget code. `git pull origin master`

run `gulp build --local=false; echo \"Starting server at localhost:8080\"; python3 -m http.server 8080;`
open an incognito window in chrome and type in an email to send. You should get an email configuration error.
<img width="595" alt="screen shot 2016-12-17 at 12 22 11 pm" src="https://cloud.githubusercontent.com/assets/2440148/21289476/7c35e0c2-c453-11e6-9fc4-b99bb61f7cbb.png">

This error was the result of passing the options ID to the YesGraph API incorrectly, resulting in the YesGraph API using a set of superwidget options that do not have email sending configured.

Now we're going to test the fix.

switch branches `git checkout -B team_invite_fix`
pull the new branch `git pull origin team_invite_fix`
You also must be running the YesGraph API locally, with the new team_invite_fix branch.

run the npm server and point it at the local server `gulp build **--local=true;** echo \"Starting server at localhost:8080\"; python3 -m http.server 8080;`

You may also need to copy the production DB superwidget_options entries for the app with name="ebb8181c-26c7-4fcf-abaa-24dbd8b7a1b1" to your local db. And the App entry too, for the app with the same name.

Enter an email and and click "send email". You should be greeted with a green success message.

### But what happened?
Please refer to [this YesGraph API PR](https://github.com/YesGraph/api.yesgraph.com/pull/790) for a more detailed explanation of the error case.
