### PR TITLE
Email subdomains

### DIFF
--- a/src/dev/modules/api.js
+++ b/src/dev/modules/api.js
@@ -14,7 +14,7 @@ export default function YesGraphAPIConstructor() {
     };
 
     var self = this;
-    var optionsDeferred;
+    this._optionsDeferred = null;
 
     this.hitAPI = function (endpoint, method, data, done, maxTries, interval) {
         var d = jQuery.Deferred();
@@ -122,23 +122,26 @@ export default function YesGraphAPIConstructor() {
 
     this.setOptions = function(options) {
         requireScript("jQuery", "https://code.jquery.com/jquery-2.1.1.min.js", () => {
-            if (!optionsDeferred || optionsDeferred.state() != "pending") {
-                optionsDeferred = jQuery.Deferred();
+            if (!self._optionsDeferred || self._optionsDeferred.state() != "pending") {
+                self._optionsDeferred = jQuery.Deferred();
             }
-            optionsDeferred.resolve(parseOptions(options));
+            self._optionsDeferred.resolve(parseOptions(options));
         });
     };
 
     this.install = function() {
         var ravenDeferred = jQuery.Deferred();
         var authDeferred = jQuery.Deferred();
-        if (!optionsDeferred || optionsDeferred.state() != "pending") {
-            optionsDeferred = jQuery.Deferred();
+        if (!self._optionsDeferred) {
+            self._optionsDeferred = jQuery.Deferred();
         }
         self.AnalyticsManager = new AnalyticsManager(self);
         self.AnalyticsManager.log(EVENTS.LOAD_JS_SDK);
 
-        waitForOptions(optionsDeferred).done(options => {
+        waitForOptions(self._optionsDeferred).done(options => {
+            // Reset the optionsDeferred
+            self._optionsDeferred = undefined;
+
             // Save parsed options
             self.app = options.auth.app;
             self.clientKey = options.auth.clientKey;

--- a/src/dev/modules/controller.js
+++ b/src/dev/modules/controller.js
@@ -30,7 +30,7 @@ export default function Controller(model, view) {
 
             if (elem.is("textarea")) {
                 var text = elem.val();
-                var regex = /([^<>\s,.;]*@[^<>\s,.;]*\.[^<>\s,.;]*)/gi;
+                var regex = /([^<>\s,.;]*@([^<>\s,.;]*\.[^<>\s,.;]*)*)/gi;
                 var match, lastMatchEnd = 0;
                 while(true) {
                     match = regex.exec(text);

--- a/tests/test_api.js
+++ b/tests/test_api.js
@@ -124,6 +124,29 @@ describe('testAPI', function() {
             window.YesGraphAPI.noConflict();
             window.YesGraphAPI = oldAPI;
         });
+
+        it('Should load properly if `setOptions` is called before `install`', function(done) {
+            // Remove the old instance of YesGraph
+            var oldAPI = YesGraphAPI.noConflict();
+            expect(window.YesGraphAPI).not.toBeDefined();
+
+            // Create a new instance & set options before installing
+            window.YesGraphAPI = new YesGraphAPIConstructor();
+            YesGraphAPI.setOptions({ auth: { app: oldAPI.app } });
+            YesGraphAPI.install();
+
+            // Check that it succesfully installed          
+            var interval = setInterval(function(){
+                if (YesGraphAPI.isReady) {
+                    clearInterval(interval);
+                    done();
+                }
+            }, 100);
+
+            // Cleanup! We should replace the original YesGraphAPI object
+            // because the Superwidget is associated with that instance
+            window.YesGraphAPI = oldAPI;
+        });
     });
 
     describe("testEndpoints", function() {

--- a/tests/test_superwidget.js
+++ b/tests/test_superwidget.js
@@ -242,78 +242,44 @@ describe('testSuperwidgetUI', function() {
 
             inputField.val(emails.join(",")); // separated by comma
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
-            expect(recipients.length).toEqual(emails.length);
-            recipients.forEach(function(recipient){
-                if (recipient.email === emails[0]) {
-                    expect(recipient.name).toEqual("Valid Email 1");
-                } else if (recipient.email === emails[1]) {
-                    expect(recipient.name).not.toBeDefined();
-                } else if (recipient.email === emails[2]) {
-                    expect(recipient.name).toEqual("Valid Email 3");
-                } else {
-                    expect(true).toEqual(false);  // fail the test
-                }
-            });
+            validateRecipientParsing(recipients, emails)
 
             inputField.val(emails.join(";")); // separated by semicolon
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
-            expect(recipients.length).toEqual(emails.length);
-            recipients.forEach(function(recipient){
-                if (recipient.email === emails[0]) {
-                    expect(recipient.name).toEqual("Valid Email 1");
-                } else if (recipient.email === emails[1]) {
-                    expect(recipient.name).not.toBeDefined();
-                } else if (recipient.email === emails[2]) {
-                    expect(recipient.name).toEqual("Valid Email 3");
-                } else {
-                    expect(true).toEqual(false);  // fail the test
-                }
-            });
+            validateRecipientParsing(recipients, emails)
 
             inputField.val(emails.join(" ")); // separated by space
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
-            expect(recipients.length).toEqual(emails.length);
-            recipients.forEach(function(recipient){
-                if (recipient.email === emails[0]) {
-                    expect(recipient.name).toEqual("Valid Email 1");
-                } else if (recipient.email === emails[1]) {
-                    expect(recipient.name).not.toBeDefined();
-                } else if (recipient.email === emails[2]) {
-                    expect(recipient.name).toEqual("Valid Email 3");
-                } else {
-                    expect(true).toEqual(false);  // fail the test
-                }
-            });
+            validateRecipientParsing(recipients, emails)
 
             inputField.val(emails.join("\n")); // separated by newline
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
-            expect(recipients.length).toEqual(emails.length);
-            recipients.forEach(function(recipient){
-                if (recipient.email === emails[0]) {
-                    expect(recipient.name).toEqual("Valid Email 1");
-                } else if (recipient.email === emails[1]) {
-                    expect(recipient.name).not.toBeDefined();
-                } else if (recipient.email === emails[2]) {
-                    expect(recipient.name).toEqual("Valid Email 3");
-                } else {
-                    expect(true).toEqual(false);  // fail the test
-                }
-            });
+            validateRecipientParsing(recipients, emails)
 
             inputField.val(emails.join("\n, ")); // combined delimiters
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
-            expect(recipients.length).toEqual(emails.length);
-            recipients.forEach(function(recipient){
-                if (recipient.email === emails[0]) {
-                    expect(recipient.name).toEqual("Valid Email 1");
-                } else if (recipient.email === emails[1]) {
-                    expect(recipient.name).not.toBeDefined();
-                } else if (recipient.email === emails[2]) {
-                    expect(recipient.name).toEqual("Valid Email 3");
-                } else {
-                    expect(true).toEqual(false);  // fail the test
-                }
-            });
+            validateRecipientParsing(recipients, emails)
+
+            function validateRecipientParsing(recipients, emails) {
+                expect(recipients.length).toEqual(emails.length);
+                recipients.forEach(function(recipient){
+                    switch (recipient.email) {
+                        case "valid+1@email.com":
+                            expect(recipient.name).toEqual("Valid Email 1");
+                            break;
+                        case "valid+2@email.com":
+                            expect(recipient.name).not.toBeDefined();
+                            break;
+                        case "valid+3@email.com":
+                            expect(recipient.name).toEqual("Valid Email 3");
+                            break;
+                        default:
+                            console.log("Email parsing failed for:", recipient.email, recipient.name);
+                            expect(emails.indexOf(recipient.email)).not.toEqual(-1);  // fail the test
+                    }
+                });
+            }
+
         });
     });
 

--- a/tests/test_superwidget.js
+++ b/tests/test_superwidget.js
@@ -225,20 +225,30 @@ describe('testSuperwidgetUI', function() {
             }()).toEqual(0); // No valid recipients should be returned
         });
 
+        it("Should handle multiple email subdomains", function() {
+            var inputField = widget.container.find(".yes-manual-input-field");
+            inputField.val("valid@email.co.uk");
+
+            expect(function(){
+                var recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
+                return recipients[0].email;
+            }()).toEqual("valid@email.co.uk");
+        })
+
         it("Should identify multiple email recipients", function() {
             var inputField = widget.container.find(".yes-manual-input-field");
-            var emails = ["Valid Email 1 <valid+1@email.com>", "valid+2@email.com", "Valid Email 3 <valid+3@email.com>"];
+            var emails = ["Valid Email 1 <valid+1@email.com>", "valid+2@email.co.uk", "Valid Email 3 <valid+3@email.com>"];
             var recipients;
 
             inputField.val(emails.join(",")); // separated by comma
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
             recipients.forEach(function(recipient){
-                if (recipient.email === "valid+1@email.com") {
+                if (recipient.email === emails[0]) {
                     expect(recipient.name).toEqual("Valid Email 1");
-                } else if (recipient.email === "valid+2@email.com") {
+                } else if (recipient.email === emails[1]) {
                     expect(recipient.name).not.toBeDefined();
-                } else if (recipient.email === "valid+3@email.com") {
+                } else if (recipient.email === emails[2]) {
                     expect(recipient.name).toEqual("Valid Email 3");
                 } else {
                     expect(true).toEqual(false);  // fail the test
@@ -249,11 +259,11 @@ describe('testSuperwidgetUI', function() {
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
             recipients.forEach(function(recipient){
-                if (recipient.email === "valid+1@email.com") {
+                if (recipient.email === emails[0]) {
                     expect(recipient.name).toEqual("Valid Email 1");
-                } else if (recipient.email === "valid+2@email.com") {
+                } else if (recipient.email === emails[1]) {
                     expect(recipient.name).not.toBeDefined();
-                } else if (recipient.email === "valid+3@email.com") {
+                } else if (recipient.email === emails[2]) {
                     expect(recipient.name).toEqual("Valid Email 3");
                 } else {
                     expect(true).toEqual(false);  // fail the test
@@ -264,11 +274,11 @@ describe('testSuperwidgetUI', function() {
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
             recipients.forEach(function(recipient){
-                if (recipient.email === "valid+1@email.com") {
+                if (recipient.email === emails[0]) {
                     expect(recipient.name).toEqual("Valid Email 1");
-                } else if (recipient.email === "valid+2@email.com") {
+                } else if (recipient.email === emails[1]) {
                     expect(recipient.name).not.toBeDefined();
-                } else if (recipient.email === "valid+3@email.com") {
+                } else if (recipient.email === emails[2]) {
                     expect(recipient.name).toEqual("Valid Email 3");
                 } else {
                     expect(true).toEqual(false);  // fail the test
@@ -279,11 +289,11 @@ describe('testSuperwidgetUI', function() {
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
             recipients.forEach(function(recipient){
-                if (recipient.email === "valid+1@email.com") {
+                if (recipient.email === emails[0]) {
                     expect(recipient.name).toEqual("Valid Email 1");
-                } else if (recipient.email === "valid+2@email.com") {
+                } else if (recipient.email === emails[1]) {
                     expect(recipient.name).not.toBeDefined();
-                } else if (recipient.email === "valid+3@email.com") {
+                } else if (recipient.email === emails[2]) {
                     expect(recipient.name).toEqual("Valid Email 3");
                 } else {
                     expect(true).toEqual(false);  // fail the test
@@ -294,11 +304,11 @@ describe('testSuperwidgetUI', function() {
             recipients = window.YesGraphAPI.utils.getSelectedRecipients(inputField);
             expect(recipients.length).toEqual(emails.length);
             recipients.forEach(function(recipient){
-                if (recipient.email === "valid+1@email.com") {
+                if (recipient.email === emails[0]) {
                     expect(recipient.name).toEqual("Valid Email 1");
-                } else if (recipient.email === "valid+2@email.com") {
+                } else if (recipient.email === emails[1]) {
                     expect(recipient.name).not.toBeDefined();
-                } else if (recipient.email === "valid+3@email.com") {
+                } else if (recipient.email === emails[2]) {
                     expect(recipient.name).toEqual("Valid Email 3");
                 } else {
                     expect(true).toEqual(false);  // fail the test


### PR DESCRIPTION
### What’s this PR do?
#### Enables the Superwidget to properly handle emails with multiple subdomains
Previously, it would parse the first subdomain and then ignore the rest. For example, email@domain.co.uk would become email@domain.co
#### Fixes a bug whereby if the `setOptions` method was called before the `install` method, the widget wouldn't load at all.
The `install` method is called by our script, and `setOptions` should normally be called later. however, if the browser is slow to load our script, then `setOptions` may sometimes run first. For example:
```html
<script src="//cdn.yesgraph.com/yesgraph-invites.min.js"></script>
<script>
// Occasionally, this method will run before the `install` method is called in the file above
YesGraphAPI.setOptions({ auth: { clientKey: "abc123" } });
</script>
```

### Where should the reviewer start?
Start by reviewing the email regex bugfix in [src/dev/modules/controller.js](https://github.com/YesGraph/yesgraph-superwidget/pull/52/files#diff-8c035b00ddc819ddafb4a3c31fc1ed1b). If you'd like to see a breakdown of how it's working, check out [this link](https://regex101.com/r/Lm8nIS/1). The regex itself is pretty opaque, but it's well tested so don't worry.

Then check out the changes in [src/dev/modules/api.js](https://github.com/YesGraph/yesgraph-superwidget/pull/52/files#diff-9e49f072ce2ba55256d8e89b0bfa1214), which fixes the `setOptions` bug.

### Does this require changes on the API side?
No

### How should this be manually tested?
I've updated the tests for both of these changes, so just run `npm test`

### What are the relevant tickets?
[Asana: Sometimes the widget doesn't load if setOptions is used](https://app.asana.com/0/59202558034519/238180814711514)
[Asana: Fix superwidget email parsing for multi-part domains](https://app.asana.com/0/59202558034519/218482265215467)

### Does the knowledge base need an update?
No
