### PR TITLE
Always include user_id with /suggested-seen entries

### DIFF
--- a/src/dev/modules/api.js
+++ b/src/dev/modules/api.js
@@ -96,8 +96,8 @@ export default function YesGraphAPIConstructor() {
     };
 
     this.postSuggestedSeen = function (seenContacts, done, maxTries, interval) {
-        // Ensure that a `user_id` is included whenever clientKey auth is used
-        if (self.clientKey != undefined && seenContacts.entries) {  // jshint ignore:line
+        // Ensure that a `user_id` is included
+        if (seenContacts.entries) {  // jshint ignore:line
             seenContacts.entries.forEach(entry => entry.user_id = entry.user_id || self.user.user_id);
         }
         return self.hitAPI("/suggested-seen", "POST", seenContacts, done, maxTries, interval);
@@ -260,6 +260,7 @@ export default function YesGraphAPIConstructor() {
             self.inviteLink = data.inviteLink;
             self.clientToken = data.token;
             self.utils.setCookie('yg-client-token', data.token);
+            self.user.user_id = data.user_id;
         },
         getOrFetchClientToken: function (userData) {
             var data = {

--- a/tests/fixtures/fixtures1.html
+++ b/tests/fixtures/fixtures1.html
@@ -1,4 +1,4 @@
-<!-- Default setup -->
+<!-- Full Widget w/ Client Token Auth -->
 <div id="yesgraph" class="yesgraph-invites"
      data-app="19185f1f-a583-4c6b-bc5f-8aff04dc1020"
      data-referral_code="1234"

--- a/tests/fixtures/fixtures3.html
+++ b/tests/fixtures/fixtures3.html
@@ -1,0 +1,6 @@
+<!-- Full Widget w/ Client Key Auth -->
+<div id="yesgraph" class="yesgraph-invites"
+     data-client-key="WzEsMCwiMTkxODVmMWYtYTU4My00YzZiLWJjNWYtOGFmZjA0ZGMxMDIwIiwibnZpZSJd.C1ht3Q.K82tVZGMVIASz8OEYElynbXbRkU"
+     data-referral_code="1234"
+     data-testmode=true>
+</div>

--- a/tests/master.js
+++ b/tests/master.js
@@ -9,11 +9,15 @@ var tests = require("./specs/*.js", { hash: true });
 var configurations = [
     {
         tests: ['test_api', 'test_superwidget'],
-        fixture: 'fixtures1.html.js'
+        fixture: 'fixtures1.html.js'  // full widget w/ client token auth
     },
     {
         tests: ['test_api', 'test_superwidget'],
-        fixture: 'fixtures2.html.js'
+        fixture: 'fixtures2.html.js'  // contact importer w/ client token auth
+    },
+    {
+        tests: ['test_api', 'test_superwidget'],
+        fixture: 'fixtures3.html.js'  // full widget w/ client key auth
     },
 ];
 

--- a/tests/specs/test_superwidget.js
+++ b/tests/specs/test_superwidget.js
@@ -349,6 +349,7 @@ module.exports = function runTests(fixtures) {
             });
 
             it('Should handle empty contacts list', function() {
+                spyOn(YesGraphAPI, "hitAPI"); // skip the api hits
                 widget.modal.loadContacts([]);
                 var modalSendBtn = widget.modal.container.find(".yes-modal-submit-btn");
                 var modalTitle = widget.modal.container.find(".yes-modal-title");
@@ -357,6 +358,7 @@ module.exports = function runTests(fixtures) {
             });
 
             it('Should optionally exclude suggestions', function() {
+                spyOn(YesGraphAPI, "hitAPI"); // skip the api hits
                 var personCount = 30;
                 var emailsPerPerson = 3;
                 var invalidEntryCount = 5;
@@ -371,6 +373,7 @@ module.exports = function runTests(fixtures) {
             });
 
             it('Should display contacts', function() {
+                spyOn(YesGraphAPI, "hitAPI"); // skip the api hits
                 // Generate dummy contact entries to load into the widget
                 var personCount = 30;
                 var emailsPerPerson = 3;
@@ -387,6 +390,7 @@ module.exports = function runTests(fixtures) {
             });
 
             it('Should allow selecting contacts', function() {
+                spyOn(YesGraphAPI, "hitAPI"); // skip the api hits
                 // Generate dummy contact entries to load into the widget
                 var personCount = 10, emailsPerPerson = 2, invalidEntryCount = 0;
                 var contacts = generateContacts(personCount, emailsPerPerson, invalidEntryCount);
@@ -426,6 +430,7 @@ module.exports = function runTests(fixtures) {
             });
 
             it('Should correctly handle contacts with the same name', function() {
+                spyOn(YesGraphAPI, "hitAPI"); // skip the api hits
                 var emails = ["jane.doe@gmail.com", "jdoe@yahoo.net",
                               "jane.doe@about.me", "jdoe@hotmail.com"];
                 var contacts = [
@@ -451,6 +456,7 @@ module.exports = function runTests(fixtures) {
             });
 
             it('Should log suggested seen analytics', function() {
+                spyOn(YesGraphAPI, "hitAPI"); // skip the api hits
                 spyOn(YesGraphAPI.AnalyticsManager, "log").and.callFake(function(evt){
                     expect(evt).toEqual("Viewed Suggested Contacts");
                 });


### PR DESCRIPTION
### What’s this PR do?
Ensures that the Superwidget always passes a `user_id` when hitting the /suggested-seen endpoint.

### Any background context you want to provide?
Previously our docs listed the `user_id` as required, but it wasn't enforced by the API. Now that the API enforces it, we need to make sure the widget complies.

### Where should the reviewer start?
src/dev/modules/api.js

### Does this require changes on the API side?
Nope

### How should this be manually tested?
I've updated the tests, so just run `npm test`

### Does the knowledge base need an update?
Nope