### PR TITLE
User ids

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### What’s this PR do?
+
+### Any background context you want to provide?
+
+### Where should the reviewer start?
+
+### Does this require changes on the API side?
+
+### How should this be manually tested?
+
+### What are the relevant tickets?
+
+### Screenshots (if appropriate)
+
+### Does the knowledge base need an update?

--- a/src/dev/modules/api.js
+++ b/src/dev/modules/api.js
@@ -104,10 +104,18 @@ export default function YesGraphAPIConstructor() {
     };
 
     this.postInvitesAccepted = function (invitesAccepted, done, maxTries, interval) {
+        // Ensure that a `user_id` is included
+        if (invitesAccepted.entries) {
+            invitesAccepted.entries.forEach(entry => entry.user_id = entry.user_id || self.user.user_id);
+        }
         return self.hitAPI("/invites-accepted", "POST", invitesAccepted, done, maxTries, interval);
     };
 
     this.postInvitesSent = function (invitesSent, done, maxTries, interval) {
+        // Ensure that a `user_id` is included
+        if (invitesSent.entries) {
+            invitesSent.entries.forEach(entry => entry.user_id = entry.user_id || self.user.user_id);
+        }
         return self.hitAPI("/invites-sent", "POST", invitesSent, done, maxTries, interval);
     };
 

--- a/tests/specs/test_api.js
+++ b/tests/specs/test_api.js
@@ -242,7 +242,6 @@ module.exports = function runTests(fixtures) {
                 var spy = spyOn(YesGraphAPI, "hitAPI").and.callFake(function(endpoint, _, data) {
                     // Check that user_ids were added to the entries
                     if (endpoint === "/suggested-seen") {
-                        console.debug(data.entries.slice(0,5))
                         data.entries.forEach(function(entry) {
                             expect(entry.user_id).toBeDefined();
                         });
@@ -261,6 +260,32 @@ module.exports = function runTests(fixtures) {
                 var userId = YesGraphAPI.user.user_id;
                 YesGraphAPI.user.user_id = userId || null;
                 YesGraphAPI.postSuggestedSeen({ entries: entries });
+            });
+
+            it('Should add a `user_id` when hitting /invites-sent & invites-accepted', function(done) {
+                expect(YesGraphAPI).toBeDefined();
+                var spy = spyOn(YesGraphAPI, "hitAPI").and.callFake(function(endpoint, _, data) {
+                    // Check that user_ids were added to the entries
+                    if (endpoint === "/invites-sent" || endpoint === "/invites-accepted") {
+                        data.entries.forEach(function(entry) {
+                            expect(entry.user_id).toBeDefined();
+                        });
+                        YesGraphAPI.user.user_id = userId;
+                        done();
+                    }
+                });
+
+                // POST some entries without user_ids
+                var entries = [
+                    { "email": "test1@email.com" },
+                    { "email": "test2@email.com" },
+                    { "email": "test3@email.com" },
+                ];
+
+                var userId = YesGraphAPI.user.user_id;
+                YesGraphAPI.user.user_id = userId || null;
+                YesGraphAPI.postInvitesSent({ entries: entries });
+                YesGraphAPI.postInvitesAccepted({ entries: entries });
             });
 
             it('Should POST to /invites-sent endpoint', function() {


### PR DESCRIPTION
### What’s this PR do?
- Ensures that a `user_id` is included whenever we hit /invites-sent or /invites-accepted
- Adds a PR template 🤓

### Any background context you want to provide?
Previously we weren't enforcing the requried `user_id` for those endpoints. Now that we are, it has started causing errors.

### Where should the reviewer start?
src/dev/modules/api.js

### Does this require changes on the API side?
Nope

### How should this be manually tested?
I've updated the tests, so you can just run `gulp test`

### What are the relevant tickets?
[Asana: Include user_id with Superwidget invites sent & accepted](https://app.asana.com/0/59202558034519/271214222370308)

### Does the knowledge base need an update?
Nope